### PR TITLE
Specify executable for building scripts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@ of those changes to CLEARTYPE SRL.
 
 | Username | Name |
 | :------- | :--- |
+| @bendemaree | Ben Demaree |

--- a/setup.py
+++ b/setup.py
@@ -58,4 +58,7 @@ setup(
     extras_require=extra_dependencies,
     entry_points={"console_scripts": ["dramatiq = dramatiq.__main__:main"]},
     scripts=["bin/dramatiq-gevent"],
+    options={
+        "build_scripts": {"executable": "/usr/bin/env python3"}
+    }
 )


### PR DESCRIPTION
This should resolve #2. The path to the virtualenv is added when the wheel is build; it becomes the shebang at the top of `dramatiq-<version>.data/scripts/dramatiq-gevent` in the wheel that's generated.