### PR TITLE
Provide a URLRabbitmqBroker, configurable via URL

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@ of those changes to CLEARTYPE SRL.
 
 | Username | Name |
 | :------- | :--- |
+| [whalesalad](http://github.com/whalesalad) | Michael Whalen |

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -33,6 +33,9 @@ Brokers
 .. autoclass:: dramatiq.brokers.rabbitmq.RabbitmqBroker
    :members:
    :inherited-members:
+.. autoclass:: dramatiq.brokers.rabbitmq.URLRabbitmqBroker
+   :members:
+   :inherited-members:
 .. autoclass:: dramatiq.brokers.redis.RedisBroker
    :members:
    :inherited-members:

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -22,7 +22,7 @@ class RabbitmqBroker(Broker):
     Parameters:
       middleware(list[Middleware]): The set of middleware that apply
         to this broker.
-      \**parameters(dict): The connection parameters to use to
+      \**parameters(dict): The (pika) connection parameters to use to
         determine which Rabbit server to connect to.
     """
 
@@ -326,6 +326,22 @@ class _RabbitmqConsumer(Consumer):
                 pika.exceptions.ChannelClosed,
                 pika.exceptions.ConnectionClosed) as e:
             raise ConnectionClosed(e) from None
+
+
+class URLRabbitmqBroker(RabbitmqBroker):
+    """Extends RabbitmqBroker to provide configuration
+    via URL instead of parameter dict.
+
+    Parameters:
+      url: A pika connection url, eg: amqp://guest:guest@localhost:5672
+      middleware(list[Middleware]): The set of middleware that apply
+        to this broker.
+    """
+
+    def __init__(self, url, middleware=None):
+        super().__init__(middleware=middleware)
+
+        self.parameters = pika.URLParameters(url)
 
 
 class _RabbitmqMessage(MessageProxy):


### PR DESCRIPTION
I'm sure there are style violations or similar here, let me know what I can do to clean this up so it is ready to merge (assuming this addition is desired).

We tend to use ENV variables at FarmLogs to configure our applications. In this sense we often rely on RABBITMQ_URL as a convention.

Fortunately this was easy enough to implement in my own codebase, but I figured others might appreciate this convenience as well. Another nice benefit of this approach is I no longer need to be concerned with `import pika` in my code and can rely wholly on Dramatiq.

This allows you to instantiate a URLRabbitmqBroker with a simple `url` parameter which will get threaded into Pika's [`URLParameters`](http://pika.readthedocs.io/en/0.10.0/examples/using_urlparameters.html)

I also updated the docstring for the regular `RabbitmqBroker` so that it would be a little more clear that the parameters are specifically for [pika connection parameters](http://pika.readthedocs.io/en/0.10.0/modules/parameters.html). (a link might be good too but not sure how your doc rendering system likes to handle that)