### PR TITLE
Startup exception logging

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ of those changes to CLEARTYPE SRL.
 | :------- | :--- |
 | [@bendemaree](https://github.com/bendemaree) | Ben Demaree |
 | [@whalesalad](https://github.com/whalesalad) | Michael Whalen |
+| [@rakanalh](https://github.com/rakanalh) | Rakan Alhneiti |

--- a/dramatiq/__main__.py
+++ b/dramatiq/__main__.py
@@ -115,7 +115,7 @@ def worker_process(args, worker_id, logging_fd):
         worker = Worker(broker, worker_threads=args.threads)
         worker.start()
     except ImportError:
-        logger.exception("Failed to import module")
+        logger.exception("Failed to import module.")
         return os._exit(2)
     except ConnectionError:
         logger.exception("Broker connection failed.")

--- a/dramatiq/__main__.py
+++ b/dramatiq/__main__.py
@@ -114,11 +114,11 @@ def worker_process(args, worker_id, logging_fd):
 
         worker = Worker(broker, worker_threads=args.threads)
         worker.start()
-    except ImportError as e:
-        logger.critical(e)
+    except ImportError:
+        logger.exception("Failed to import module")
         return os._exit(2)
-    except ConnectionError as e:
-        logger.critical("Broker connection failed. %s", e)
+    except ConnectionError:
+        logger.exception("Broker connection failed.")
         return os._exit(3)
 
     def termhandler(signum, frame):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ def test_cli_fails_to_start_given_an_invalid_broker_name(start_cli):
     assert proc.returncode == 2
 
     # And the output should contain an error
-    assert b"[CRITICAL] Module 'tests.test_cli' does not define a 'idontexist' variable." in proc.stdout.read()
+    assert b"Module 'tests.test_cli' does not define a 'idontexist' variable." in proc.stdout.read()
 
 
 def test_cli_fails_to_start_given_an_invalid_broker_instance(start_cli):
@@ -26,4 +26,4 @@ def test_cli_fails_to_start_given_an_invalid_broker_instance(start_cli):
     assert proc.returncode == 2
 
     # And the output should contain an error
-    assert b"[CRITICAL] Variable 'fakebroker' from module 'tests.test_cli' is not a Broker." in proc.stdout.read()
+    assert b"Variable 'fakebroker' from module 'tests.test_cli' is not a Broker." in proc.stdout.read()


### PR DESCRIPTION
Use exception so that the stack trace could indicate where exceptions are happening.