### PR TITLE
Change dependency handling

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,4 @@ of those changes to CLEARTYPE SRL.
 | [@chen2aaron](https://github.com/chen2aaron) | xixijun |
 | [@aequitas](https://github.com/aequitas) | Johan Bloemberg |
 | [@najamansari](https://github.com/najamansari) | Najam Ahmed Ansari |
+| [@rpkilby](https://github.com/rpkilby) | Ryan P Kilby |

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,6 @@ for extra in extras:
     extra_dependencies[extra] = list(parse_dependencies(filename))
 
 extra_dependencies["all"] = list(set(sum(extra_dependencies.values(), [])))
-extra_dependencies[""] = list(set(
-    extra_dependencies["rabbitmq"] +
-    extra_dependencies["watch"]
-))
 
 setup(
     name="dramatiq",


### PR DESCRIPTION
Should fix #60

- Makes prometheus an extra dependency
- Don't always install rabbitmq+watch dependencies