### PR TITLE
Signal processing improvement

### DIFF
--- a/dramatiq/__main__.py
+++ b/dramatiq/__main__.py
@@ -332,6 +332,8 @@ def main():  # noqa
     def watch_logs(worker_pipes):
         nonlocal running
 
+        signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT, signal.SIGTERM, signal.SIGHUP})
+
         log_file = args.log_file or sys.stderr
         selector = selectors.DefaultSelector()
         for pipe in [parent_read_pipe] + worker_pipes:


### PR DESCRIPTION
According `python` docs `Python signal handlers are always executed in the main Python thread`, but sometimes this is not true. This problem is too old, and on some OSs it periodically take place.
FreeBSD 10.3 amd64 send signal for last python thread, and it is not processed. FreeBSD 11.0 is not affected. Problem occurs on python 3.6 and 3.8.
Blocking signal processing in thread resolves problem independently of OS.