### PR TITLE
Recompute keys in atomic incr with sliding window

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,3 +17,4 @@ of those changes to CLEARTYPE SRL.
 | [@najamansari](https://github.com/najamansari) | Najam Ahmed Ansari |
 | [@rpkilby](https://github.com/rpkilby) | Ryan P Kilby |
 | [@2miksyn](https://github.com/2miksyn) | Mikhail Smirnov |
+| [@gdvalle](https://github.com/gdvalle) | Greg Dallavalle |

--- a/dramatiq/rate_limits/backend.py
+++ b/dramatiq/rate_limits/backend.py
@@ -64,8 +64,8 @@ class RateLimiterBackend:
         raise NotImplementedError
 
     def incr_and_sum(self, key, keys, amount, maximum, ttl):  # pragma: no cover
-        """Atomically increment a key and return the sum of a set of
-        keys, unless the sum is greater than the given maximum.
+        """Atomically increment a key unless the sum of keys is greater
+        than the given maximum.
 
         Parameters:
           key(str): The key to increment.

--- a/dramatiq/rate_limits/backend.py
+++ b/dramatiq/rate_limits/backend.py
@@ -69,6 +69,8 @@ class RateLimiterBackend:
 
         Parameters:
           key(str): The key to increment.
+          keys(callable): A callable to return the list of keys to be
+            summed over.
           amount(int): The amount to decrement the value by.
           maximum(int): The maximum sum of the keys.
           ttl(int): The max amount of time in milliseconds the key can

--- a/dramatiq/rate_limits/backends/memcached.py
+++ b/dramatiq/rate_limits/backends/memcached.py
@@ -100,7 +100,9 @@ class MemcachedBackend(RateLimiterBackend):
                 if value > maximum:
                     return False
 
-                mapping = client.get_multi(keys)
+                # TODO: Drop non-callable keys in Dramatiq v2.
+                key_list = keys() if callable(keys) else keys
+                mapping = client.get_multi(key_list)
                 total = amount + sum(mapping.values())
                 if total > maximum:
                     return False

--- a/dramatiq/rate_limits/backends/stub.py
+++ b/dramatiq/rate_limits/backends/stub.py
@@ -61,7 +61,9 @@ class StubBackend(RateLimiterBackend):
             if value > maximum:
                 return False
 
-            values = sum(self._get(k, default=0) for k in keys)
+            # TODO: Drop non-callable keys in Dramatiq v2.
+            key_list = keys() if callable(keys) else keys
+            values = sum(self._get(k, default=0) for k in key_list)
             total = amount + values
             if total > maximum:
                 return False

--- a/dramatiq/rate_limits/window.py
+++ b/dramatiq/rate_limits/window.py
@@ -48,14 +48,14 @@ class WindowRateLimiter(RateLimiter):
         self.window = window
         self.window_millis = window * 1000
 
-    def _acquire(self):
+    def _get_keys(self):
         timestamp = int(time.time())
-        keys = ["%s@%s" % (self.key, timestamp - i) for i in range(self.window)]
+        return ["%s@%s" % (self.key, timestamp - i) for i in range(self.window)]
 
-        # TODO: This is susceptible to drift because the keys are
-        # never re-computed when CAS fails.
+    def _acquire(self):
+        keys = self._get_keys()
         return self.backend.incr_and_sum(
-            keys[0], keys, 1,
+            keys[0], self._get_keys, 1,
             maximum=self.limit,
             ttl=self.window_millis,
         )


### PR DESCRIPTION
Change the `WindowRateLimiter` to pass a callable to `incr_and_sum` so
that during atomic increments the time windows can be recomputed in the
event of a lock.

This breaks the API because we change `incr_and_sum`'s `keys` arg to
a callable. We keep backwards compatibility by checking if `keys` is
callable and calling it on each use.