### PR TITLE
Make test suite more friendly to new contributors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
   - "3.7-dev" # 3.7 development branch
   - "nightly"
 matrix:
+  include:
+    - { python: "3.6", env: TOXENV=flake8 }
   allow_failures:
     - python: "3.6-dev"
     - python: "3.7-dev"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,14 +77,6 @@ def rabbitmq_worker(rabbitmq_broker):
 
 
 @pytest.fixture()
-def urlrabbitmq_worker(urlrabbitmq_broker):
-    worker = Worker(urlrabbitmq_broker)
-    worker.start()
-    yield worker
-    worker.stop()
-
-
-@pytest.fixture()
 def redis_worker(redis_broker):
     worker = Worker(redis_broker, worker_threads=32)
     worker.start()

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=
   py{35,36,37}-cpython
   pypy3-pypy
+  benchmarks
   flake8
 
 [testenv]
@@ -10,9 +11,17 @@ deps=
   pypy: -r{toxinidir}/requirements/dev-pypy.txt
   flake8: flake8
 commands=
-  py.test {posargs}
+  py.test --benchmark-skip {posargs}
 passenv=
   TRAVIS
+
+[testenv:benchmarks]
+deps =
+  -r{toxinidir}/requirements/dev.txt
+install_command=
+  pip install -U -c {toxinidir}/requirements/constraints.txt {opts} {packages}
+commands=
+  py.test --benchmark-only {posargs}
 
 [testenv:py36-cpython]
 install_command=

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,3 @@ install_command=
 [testenv:flake8]
 commands=
   flake8 {toxinidir}/dramatiq {toxinidir}/examples {toxinidir}/tests
-
-[travis]
-python=
-  3.5: py35
-  3.6: py36, flake8
-  3.7: py37


### PR DESCRIPTION
Hi @Bogdanp - I ran into a few issues when I started writing tests. Namely, running the test suite requires having all of the services configured correctly, which may not be the case. As a result, the test suite fails outright. If you delete the benchmarks (which cause the outright failure), the tests still result in ~80 errors due to connection failures. I've made the following changes:

- In dev, skip tests when the required rabbitmq/redis/memcached service is not available.
- Don't run the benchmarks as part of the default test suite. They're take a fair amount of time, and most users will not want to wait for them to complete. 
- Deleted a test fixture for the old url-based RabbitMQ broker

I've also made the following changes to the travis config:
- Run flake8 in its own CI job.
- Run the benchmarks on one py36 job, instead of on all of version. This can be reverted - it wasn't entirely clear to me if it was important to run the benchmarks on all versions of python.

Thoughts?