### PR TITLE
WIP: Make Prometheus an optional depencency

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ of those changes to CLEARTYPE SRL.
 | [@rpkilby](https://github.com/rpkilby) | Ryan P Kilby |
 | [@2miksyn](https://github.com/2miksyn) | Mikhail Smirnov |
 | [@gdvalle](https://github.com/gdvalle) | Greg Dallavalle |
+| [@idahogray](https://github.com/idahogray) | Keith Gray |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ or if you want to use it with [Redis]
     pipenv install 'dramatiq[redis, watch]'
 
 
+If you want to use it with [Prometheus]
+
+   pipenv install 'dramtiq[prometheus]'
+
 ## Quickstart
 
 Make sure you've got [RabbitMQ] running, then create a new file called
@@ -76,3 +80,4 @@ dramatiq is licensed under the LGPL.  Please see [COPYING] and
 [RabbitMQ]: https://www.rabbitmq.com/
 [Redis]: https://redis.io
 [user guide]: https://dramatiq.io/guide.html
+[Prometheus]: https://prometheus.io

--- a/dramatiq/__init__.py
+++ b/dramatiq/__init__.py
@@ -62,4 +62,4 @@ __all__ = [
     "Worker",
 ]
 
-__version__ = "1.2.0"
+__version__ = "2.0.0a1"

--- a/dramatiq/middleware/__init__.py
+++ b/dramatiq/middleware/__init__.py
@@ -19,11 +19,16 @@ from .age_limit import AgeLimit
 from .callbacks import Callbacks
 from .middleware import Middleware, MiddlewareError, SkipMessage
 from .pipelines import Pipelines
-from .prometheus import Prometheus
 from .retries import Retries
 from .shutdown import Shutdown, ShutdownNotifications
 from .threading import Interrupt, raise_thread_exception
 from .time_limit import TimeLimit, TimeLimitExceeded
+
+try:
+    from .prometheus import Prometheus
+    HAS_PROMETHEUS = True
+except ImportError:
+    HAS_PROMETHEUS = False
 
 __all__ = [
     # Basics
@@ -33,12 +38,16 @@ __all__ = [
     "Interrupt", "raise_thread_exception",
 
     # Middlewares
-    "AgeLimit", "Callbacks", "Pipelines", "Prometheus", "Retries",
+    "AgeLimit", "Callbacks", "Pipelines", "Retries",
     "Shutdown", "ShutdownNotifications", "TimeLimit", "TimeLimitExceeded",
 ]
 
 #: The list of middleware that are enabled by default.
 default_middleware = [
-    Prometheus, AgeLimit, TimeLimit, ShutdownNotifications,
+    AgeLimit, TimeLimit, ShutdownNotifications,
     Callbacks, Pipelines, Retries
 ]
+
+if HAS_PROMETHEUS:
+    __all__ += ["Prometheus"]
+    default_middleware += [Prometheus]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ with open(rel("dramatiq", "__init__.py"), "r") as f:
 
 
 dependencies = [
-    "prometheus-client>=0.2,<0.3",
 ]
 
 extra_dependencies = {
@@ -42,6 +41,10 @@ extra_dependencies = {
     "watch": [
         "watchdog>=0.8,<0.9",
         "watchdog_gevent==0.1",
+    ],
+
+    "prometheus": [
+        "prometheus-client>=0.2,<0.3",
     ],
 }
 


### PR DESCRIPTION
Related to #75 and #95.

* Changed prometheus-client to be optional based on supplying the prometheus extra requirement when installing
* Added myself to CONTRIBUTORS
* Updated README to document the new extra_requires option for prometheus support
* Made prometheus support optional