### PR TITLE
Fixing docs build

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@ of those changes to CLEARTYPE SRL.
 | [@viiicky](https://github.com/viiicky) | Vikas Prasad |
 | [@xdmiodz](https://github.com/xdmiodz) | Dmitry Odzerikho |
 | [@ryansm1](https://github.com/ryansm1) | Ryan Smith |
+| [@aericson](https://github.com/aericson) | André Ericson |

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ extra_dependencies["all"] = list(set(sum(extra_dependencies.values(), [])))
 extra_dependencies["dev"] = extra_dependencies["all"] + [
     # Docs
     "alabaster",
-    "sphinx",
+    "sphinx<1.8",
     "sphinxcontrib-napoleon",
     "sphinxcontrib-versioning",
 


### PR DESCRIPTION
`sphinxcontrib-versioning` does not work with sphinx 1.8.x.

Pinning version to be able to build the docs.

You can see the build error here: https://travis-ci.org/Bogdanp/dramatiq/jobs/437987961