### PR TITLE
Declare queue lazily

### DIFF
--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -171,7 +171,6 @@ class Broker:
           actor(Actor): The actor being declared.
         """
         self.emit_before("declare_actor", actor)
-        self.declare_queue(actor.queue_name)
         self.actors[actor.actor_name] = actor
         self.emit_after("declare_actor", actor)
 

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -169,6 +169,8 @@ class RedisBroker(Broker):
                 },
             )
 
+        # Make sure queue is declared
+        self.declare_queue(queue_name)
         self.logger.debug("Enqueueing message %r on queue %r.", message.message_id, queue_name)
         self.emit_before("enqueue", message, delay)
         self.do_enqueue(queue_name, message.options["redis_message_id"], message.encode())


### PR DESCRIPTION
Currently, a queue is declared when an actor is. This means a connection
to broker must be established when actors are imported. It leads to some
difficulties when you need to change some configuration parameters after
actors have been imported.

This change declare queue lazily, meaning on first message enqueuing.