### PR TITLE
Parse arguments outside of main so we can have a custom entrypoint

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@ of those changes to CLEARTYPE SRL.
 | [@xdmiodz](https://github.com/xdmiodz) | Dmitry Odzerikho |
 | [@ryansm1](https://github.com/ryansm1) | Ryan Smith |
 | [@aericson](https://github.com/aericson) | André Ericson |
+| [@maerteijn](https://github.com/maerteijn) | Martijn Jacobs |

--- a/bin/dramatiq-gevent
+++ b/bin/dramatiq-gevent
@@ -8,7 +8,7 @@ except ImportError:
 
 import sys
 
-from dramatiq.cli import main
+from dramatiq.cli import entrypoint
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(entrypoint())

--- a/dramatiq/__main__.py
+++ b/dramatiq/__main__.py
@@ -17,7 +17,7 @@
 
 import sys
 
-from dramatiq.cli import main
+from dramatiq.cli import entrypoint
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(entrypoint())

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -118,7 +118,7 @@ def folder_path(value):
     return os.path.abspath(value)
 
 
-def parse_arguments():
+def argument_parser():
     parser = argparse.ArgumentParser(
         prog="dramatiq",
         description="Run dramatiq workers.",
@@ -177,7 +177,7 @@ def parse_arguments():
 
     parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument("--verbose", "-v", action="count", default=0, help="turn on verbose log output")
-    return parser.parse_args()
+    return parser
 
 
 def setup_pidfile(filename):
@@ -322,8 +322,7 @@ def worker_process(args, worker_id, logging_pipe):
     logging_pipe.close()
 
 
-def main():  # noqa
-    args = parse_arguments()
+def main(args):  # noqa
     for path in args.path:
         sys.path.insert(0, path)
 
@@ -446,3 +445,8 @@ def main():  # noqa
         return os.execvp(sys.argv[0], sys.argv)
 
     return retcode
+
+
+def entrypoint():
+    args = argument_parser().parse_args()
+    return main(args)

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     install_requires=dependencies,
     python_requires=">=3.5",
     extras_require=extra_dependencies,
-    entry_points={"console_scripts": ["dramatiq = dramatiq.__main__:main"]},
+    entry_points={"console_scripts": ["dramatiq = dramatiq.__main__:entrypoint"]},
     scripts=["bin/dramatiq-gevent"],
     classifiers=[
         "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
With this pull request it becomes possible to write a custom entrypoint with a different argument parser or another source of arguments (for example a config file). Now this is almost impossible without monkey patching or duplicating a lot of code.

A custom entrypoint could looks like this:

```python
import sys

from dramatiq.cli import argument_parser, main


def my_entrypoint():
    args = ['my.module:broker', 'my.module.actors', '-Q', 'myqueue']
    parsed_args = argument_parser().parse_args(args)
    return main(parsed_args)

if __name__ == "__main__":
    sys.exit(my_entrypoint())
```

Changing the existing arguments or adding extra ones will be much simpler then as well. Could also simplify the `dramatiq-django` integration by calling the python module directly instead of `os.execvp`.

