### PR TITLE
WIP: Support redis py 3.0

### DIFF
--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -60,7 +60,7 @@ class RedisBroker(Broker):
       >>> RedisBroker(url="redis://127.0.0.1:6379/0")
 
     See also:
-      StrictRedis_ for a list of all the available connection parameters.
+      Redis_ for a list of all the available connection parameters.
 
     Parameters:
       url(str): An optional connection URL.  If both a URL and
@@ -77,9 +77,9 @@ class RedisBroker(Broker):
       requeue_deadline(int): Deprecated.  Does nothing.
       requeue_interval(int): Deprecated.  Does nothing.
       **parameters(dict): Connection parameters are passed directly
-        to :class:`redis.StrictRedis`.
+        to :class:`redis.Redis`.
 
-    .. _StrictRedis: http://redis-py.readthedocs.io/en/latest/#redis.StrictRedis
+    .. _Redis: http://redis-py.readthedocs.io/en/latest/#redis.Redis
     """
 
     def __init__(
@@ -107,7 +107,7 @@ class RedisBroker(Broker):
         self.heartbeat_timeout = heartbeat_timeout
         self.dead_message_ttl = dead_message_ttl
         self.queues = set()
-        self.client = client = redis.StrictRedis(**parameters)
+        self.client = client = redis.Redis(**parameters)
         self.scripts = {name: client.register_script(script) for name, script in _scripts.items()}
 
     def consume(self, queue_name, prefetch=1, timeout=5000):

--- a/dramatiq/rate_limits/backends/redis.py
+++ b/dramatiq/rate_limits/backends/redis.py
@@ -24,12 +24,12 @@ class RedisBackend(RateLimiterBackend):
     """A rate limiter backend for Redis_.
 
     Parameters:
-      client(StrictRedis): An optional client.  If this is passed,
+      client(Redis): An optional client.  If this is passed,
         then all other parameters are ignored.
       url(str): An optional connection URL.  If both a URL and
         connection paramters are provided, the URL is used.
       **parameters(dict): Connection parameters are passed directly
-        to :class:`redis.StrictRedis`.
+        to :class:`redis.Redis`.
 
     .. _redis: https://redis.io
     """
@@ -38,7 +38,7 @@ class RedisBackend(RateLimiterBackend):
         if url is not None:
             parameters["connection_pool"] = redis.ConnectionPool.from_url(url)
 
-        self.client = client or redis.StrictRedis(**parameters)
+        self.client = client or redis.Redis(**parameters)
 
     def add(self, key, value, ttl):
         return bool(self.client.set(key, value, px=ttl, nx=True))

--- a/dramatiq/results/backends/redis.py
+++ b/dramatiq/results/backends/redis.py
@@ -28,12 +28,12 @@ class RedisBackend(ResultBackend):
       namespace(str): A string with which to prefix result keys.
       encoder(Encoder): The encoder to use when storing and retrieving
         result data.  Defaults to :class:`.JSONEncoder`.
-      client(StrictRedis): An optional client.  If this is passed,
+      client(Redis): An optional client.  If this is passed,
         then all other parameters are ignored.
       url(str): An optional connection URL.  If both a URL and
         connection paramters are provided, the URL is used.
       **parameters(dict): Connection parameters are passed directly
-        to :class:`redis.StrictRedis`.
+        to :class:`redis.Redis`.
 
     .. _redis: https://redis.io
     """
@@ -44,7 +44,7 @@ class RedisBackend(ResultBackend):
         if url:
             parameters["connection_pool"] = redis.ConnectionPool.from_url(url)
 
-        self.client = client or redis.StrictRedis(**parameters)
+        self.client = client or redis.Redis(**parameters)
 
     def get_result(self, message, *, block=False, timeout=None):
         """Get a result from the backend.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extra_dependencies = {
     ],
 
     "redis": [
-        "redis>=2.10,<3",
+        "redis>=3.0.1,<4.0",
     ],
 
     "watch": [

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -336,8 +336,8 @@ def test_redis_broker_maintains_backwards_compat_with_old_acks(redis_broker):
     # And that actor has some old-style unacked messages
     expired_message_id = b"expired-old-school-ack"
     valid_message_id = b"valid-old-school-ack"
-    redis_broker.client.zadd("dramatiq:default.acks", 0, expired_message_id)
-    redis_broker.client.zadd("dramatiq:default.acks", current_millis(), valid_message_id)
+    redis_broker.client.zadd("dramatiq:default.acks", {expired_message_id: 0})
+    redis_broker.client.zadd("dramatiq:default.acks", {valid_message_id: current_millis()})
 
     # When maintenance runs for that actor's queue
     redis_broker.maintenance_chance = MAINTENANCE_SCALE


### PR DESCRIPTION
As I saw the "Help wanted" label for #136 here my first attempt (WIP) to fix the issues so Dramatiq works with the redis-py 3.0 package. 

For as far I can see from the [breaking changes](https://github.com/andymccurdy/redis-py/blob/master/CHANGES) the following issues have impact on dramatiq:

* The StrictRedis class has been renamed to Redis. StrictRedis will continue to exist as an alias of Redis for the forseeable future.
* The legacy Redis client class has been removed. It caused much confusion to users.
* ZADD now requires all element names/scores be specified in a single dictionary argument named mapping. This was required to allow the NX, XX, CH and INCR options to be specified.

These issues are addressed in this pull request. `disptach.lua` seems to work fine, however I'm not so a LUA programmer so it could be luck that it still works 😄 Will investigate later or maybe you have some hints for me