### PR TITLE
WIP: Add arbitrary composition

### DIFF
--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -19,8 +19,6 @@ import time
 import uuid
 from collections import namedtuple
 
-from .broker import get_broker
-from .composition import pipeline
 from .encoder import Encoder, JSONEncoder
 from .results import Results
 
@@ -79,9 +77,10 @@ class Message(namedtuple("Message", (
             message_timestamp=message_timestamp or int(time.time() * 1000),
         )
 
-    def __or__(self, other) -> pipeline:
+    def __or__(self, other):
         """Combine this message into a pipeline with "other".
         """
+        from .composition import pipeline
         return pipeline([self, other])
 
     def asdict(self):
@@ -135,6 +134,9 @@ class Message(namedtuple("Message", (
         Returns:
           object: The result.
         """
+        # Break the import cycle
+        from .broker import get_broker
+
         if not backend:
             broker = get_broker()
             for middleware in broker.middleware:

--- a/dramatiq/middleware/__init__.py
+++ b/dramatiq/middleware/__init__.py
@@ -20,6 +20,7 @@ import platform
 from .age_limit import AgeLimit
 from .callbacks import Callbacks
 from .middleware import Middleware, MiddlewareError, SkipMessage
+from .composition import Composition
 from .pipelines import Pipelines
 from .retries import Retries
 from .shutdown import Shutdown, ShutdownNotifications
@@ -40,7 +41,7 @@ __all__ = [
     "Interrupt", "raise_thread_exception",
 
     # Middlewares
-    "AgeLimit", "Callbacks", "Pipelines", "Retries",
+    "AgeLimit", "Callbacks", "Composition", "Pipelines", "Retries",
     "Shutdown", "ShutdownNotifications", "TimeLimit", "TimeLimitExceeded",
 ]
 

--- a/dramatiq/middleware/composition.py
+++ b/dramatiq/middleware/composition.py
@@ -1,0 +1,107 @@
+# This file is a part of Dramatiq.
+#
+# Copyright (C) 2017,2018 CLEARTYPE SRL <bogdan@cleartype.io>
+#
+# Dramatiq is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Dramatiq is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import namedtuple
+from ..message import Message
+from ..rate_limits import Barrier
+from .middleware import Middleware
+
+
+class GroupStart(namedtuple("GroupStart", ("id", "count"))):
+    """Metadata required to start a group.
+
+    Parameters:
+      id(str): The id of the group to start.
+      count(int): The number of items in the group.
+    """
+
+    def __new__(cls, *, id, count):
+        assert count, "Empty groups are not supported. Yet."
+        return super().__new__(cls, id=id, count=count)
+
+    def asdict(self):
+        return self._asdict()
+
+
+class Composition(Middleware):
+    """Middleware that can manage arbitrary compositions of messages.
+
+    Parameters:
+      backend(RateLimiterBackend): The rate limiter backend to use
+        for managing group completion barriers.
+      ttl(int): The maximum number of milliseconds group barriers
+        may exist before they time out and the group fails.
+    """
+
+    def __init__(self, backend, ttl):
+        self.backend = backend
+        self.ttl = ttl
+
+    @property
+    def actor_options(self):
+        # composition_group_ids: The group ids that must be confirmed
+        #   completed in order for the targets or starts to be acted on.
+        # composition_targets: The serialized messages that should be
+        #   run when a message's groups have all completed.
+        # composition_starts: The serialized representation of groups
+        #   that should be started when a message's groups have all completed.
+        return {
+            "composition_group_ids",
+            "composition_targets",
+            "composition_starts",
+        }
+
+    def barrier(self, group_id):
+        return Barrier(self.backend, group_id, ttl=self.ttl)
+
+    def start_group(self, group_id, count):
+        """Start the group expecting count messages."""
+        return self.barrier(group_id).create(parties=count)
+
+    def check_group(self, group_id):
+        """Check if this is the last message in the group."""
+        return self.barrier(group_id).wait(block=False)
+
+    def process(self, *, broker, group_ids=(), starts=(), targets=()):
+        # The group ids are given in the order they must resolve,
+        # from the innermost group to the final outer group.
+        # Only check outer groups when inner groups are finished.
+        if all(self.check_group(group_id) for group_id in group_ids):
+            for start in starts:
+                self.start_group(start.id, start.count)
+            for target in targets:
+                broker.enqueue(target)
+
+    def after_process_message(self, broker, message, *, result=None, exception=None):
+        if exception is not None or message.failed:
+            return
+
+        group_ids = message.options.get('composition_group_ids', [])
+        starts = [
+            GroupStart(**start)
+            for start in message.options.get('composition_starts', [])
+        ]
+        targets = [
+            Message(**target)
+            for target in message.options.get('composition_targets', [])
+        ]
+        self.process(
+            broker=broker,
+            group_ids=group_ids,
+            starts=starts,
+            targets=targets,
+        )

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -20,7 +20,11 @@ def test_messages_can_be_piped(stub_broker):
     # Then I should get back a pipeline object
     assert isinstance(pipe, pipeline)
 
-    # And each message in the pipeline should reference the next message in line
+    # And once the messages are queued
+    pipe.broker = stub_broker
+    pipe.run()
+
+    # Each message in the pipeline should reference the next message in line
     assert pipe.messages[0].options["pipe_target"] == pipe.messages[1].asdict()
     assert pipe.messages[1].options["pipe_target"] == pipe.messages[2].asdict()
     assert "pipe_target" not in pipe.messages[2].options


### PR DESCRIPTION
References #103, #150, #144.

I let myself dwell on the implementation of #144 for a while, and I eventually came up with a simple callable design, implemented here as a singledispatch function, that eliminates the weird cross-referencing of my previous attempt. However, it keeps all of the functionality, and uses essentially the same design for the data to be stored in the message options.

I've rolled all this into a new middleware I called `Composition`, and built the functionality on top of the already existing classes, rather than rolling new ones. (Though they were really helpful in allowing me to understand the basics of the design).

I haven't answered every question about how the current `pipeline` and `group` classes should behave in this new world, but I've answered how the basic mechanics of getting the tasks to run in the right way should work.

For *Right Now*, I've punted on allowing empty groups. I will make that happen, but I wanted to get this into review as soon as I could show anything useful.

I think that the design of the middleware's options is the main thing that I believe is complete for the functionality I'm looking to add in this iteration.

No tests just yet. I'll write those after I get some feedback on the direction that I've got here.