### PR TITLE
RabbitMQ priority

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,3 +1,5 @@
+import dramatiq
+from dramatiq import Worker
 from .common import worker
 
 
@@ -11,3 +13,36 @@ def test_workers_dont_register_queues_that_arent_whitelisted(stub_broker):
         # Then a consumer should not get spun up for that queue
         assert "c" not in stub_worker.consumers
         assert "c.DQ" not in stub_worker.consumers
+
+
+def test_worker_doesnt_start_consuming_when_stopped(stub_broker):
+    worker = Worker(stub_broker)
+    worker.start()
+    worker.stop()
+
+    @dramatiq.actor()
+    def should_never_run():
+        pass
+
+    should_never_run.send()
+    for consumer in worker.consumers.values():
+        assert not consumer.running
+
+
+def test_worker_start_not_running_consumers_when_starting(stub_broker):
+    worker = Worker(stub_broker)
+    worker.start()
+    worker.stop()
+    has_ran = False
+
+    @dramatiq.actor()
+    def should_run():
+        nonlocal has_ran
+        has_ran = True
+
+    should_run.send()
+    worker.start()
+    stub_broker.join("default", timeout=100)
+    worker.join()
+
+    assert has_ran


### PR DESCRIPTION
Add support to rabbitmq priority queue.
Examples and documentation are still missing, I'll add them after you'll approve it.
The idea is to send the message with options like this:
```python
some_actot.send_with_options(broker_priority=5)
```