### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,18 @@
 language: python
 sudo: required
+dist: xenial
 python:
   - "3.5"
   - "3.6"
-  - "3.6-dev"
-  - "3.7-dev"
-  - "nightly"
+  - "3.7"
 matrix:
   include:
-    - { python: "3.6", env: TOXENV=lint }
-    - { python: "3.6", env: TOXENV=docs }
-  allow_failures:
-    - python: "3.6-dev"
-    - python: "3.7-dev"
-    - python: "nightly"
-    - env: TOXENV=docs
+    - { python: "3.7", env: TOXENV=lint }
+    - { python: "3.7", env: TOXENV=docs }
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
 services:
   - memcached
   - rabbitmq


### PR DESCRIPTION
This is blocked by Travis not supporting RMQ on Xenial. We'll either have to do our own thing or move to a different CI system (like Semaphore).