### PR TITLE
Allow to specify an actor class in actor decorator.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,3 +26,4 @@ of those changes to CLEARTYPE SRL.
 | [@ryanhiebert](https://github.com/ryanhiebert) | Ryan Hiebert           |
 | [@davidt99](https://github.com/davidt99)       | davidt99               |
 | [@brownan](https://github.com/brownan)         | Andrew Brown           |
+| [@gilbsgilbs](https://github.com/gilbsgilbs)   | gilbsgilbs             |

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -21,6 +21,21 @@ def test_actors_can_be_defined(stub_broker):
     assert isinstance(add, dramatiq.Actor)
 
 
+def test_actors_can_be_declared_with_actor_class(stub_broker):
+    # Given ActorChild a subclass of Actor
+    class ActorChild(dramatiq.Actor):
+        pass
+
+    # Given that I've decorated a function with @actor
+    # If I define the actor_class
+    @dramatiq.actor(actor_class=ActorChild)
+    def add(x, y):
+        return x + y
+
+    # I expect that function to become an instance of ActorChild
+    assert isinstance(add, ActorChild)
+
+
 def test_actors_can_be_assigned_predefined_options(stub_broker):
     # Given that I have a stub broker with the retries middleware
     # If I define an actor with a max_retries number


### PR DESCRIPTION
Sorry, I had to move the decorator function down so that I can get the `Actor` class declared soon enough, which kind of messes up the diff.

Fixes #163 