### PR TITLE
Retries middleware should also account for message options

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,3 +27,4 @@ of those changes to CLEARTYPE SRL.
 | [@davidt99](https://github.com/davidt99)       | davidt99               |
 | [@brownan](https://github.com/brownan)         | Andrew Brown           |
 | [@gilbsgilbs](https://github.com/gilbsgilbs)   | gilbsgilbs             |
+| [@MihaiBalint](https://github.com/MihaiBalint) | Mihai Balint           |

--- a/dramatiq/middleware/retries.py
+++ b/dramatiq/middleware/retries.py
@@ -67,7 +67,7 @@ class Retries(Middleware):
 
         actor = broker.get_actor(message.actor_name)
         retries = message.options.setdefault("retries", 0)
-        max_retries = actor.options.get("max_retries", self.max_retries)
+        max_retries = message.options.get("max_retries") or actor.options.get("max_retries", self.max_retries)
         retry_when = actor.options.get("retry_when", self.retry_when)
         if retry_when is not None and not retry_when(retries, exception) or \
            retry_when is None and max_retries is not None and retries >= max_retries:
@@ -77,8 +77,8 @@ class Retries(Middleware):
 
         message.options["retries"] += 1
         message.options["traceback"] = traceback.format_exc(limit=30)
-        min_backoff = actor.options.get("min_backoff", self.min_backoff)
-        max_backoff = actor.options.get("max_backoff", self.max_backoff)
+        min_backoff = message.options.get("min_backoff") or actor.options.get("min_backoff", self.min_backoff)
+        max_backoff = message.options.get("max_backoff") or actor.options.get("max_backoff", self.max_backoff)
         max_backoff = min(max_backoff, DEFAULT_MAX_BACKOFF)
         _, backoff = compute_backoff(retries, factor=min_backoff, max_backoff=max_backoff)
         self.logger.info("Retrying message %r in %d milliseconds.", message.message_id, backoff)

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -306,7 +306,7 @@ def test_actors_can_be_assigned_message_max_retries(stub_broker, stub_worker):
     stub_worker.join()
 
     # Then I expect it to be retried as specified in the message options
-    assert sum(attempts) == 4
+    assert sum(attempts) == 5
 
 
 def test_actors_can_delay_messages_independent_of_each_other(stub_broker, stub_worker):


### PR DESCRIPTION
This is similar to issue #44 and the subsequent fix.