### PR TITLE
Access broker in object attributes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,8 @@ from subprocess import PIPE, STDOUT
 
 from .common import skip_on_windows
 
-fakebroker = object()
+class BrokerHolder:
+    fakebroker = object()
 
 
 @skip_on_windows
@@ -21,13 +22,13 @@ def test_cli_fails_to_start_given_an_invalid_broker_name(start_cli):
 
 @skip_on_windows
 def test_cli_fails_to_start_given_an_invalid_broker_instance(start_cli):
-    # Given that this module defines a "fakebroker" variable that's not a Broker
+    # Given that this module defines a "BrokerHolder.fakebroker" variable that's not a Broker
     # When I start the cli and point it at that broker
-    proc = start_cli("tests.test_cli:fakebroker", stdout=PIPE, stderr=STDOUT)
+    proc = start_cli("tests.test_cli:BrokerHolder.fakebroker", stdout=PIPE, stderr=STDOUT)
     proc.wait(5)
 
     # Then the process return code should be 2
     assert proc.returncode == 2
 
     # And the output should contain an error
-    assert b"Variable 'fakebroker' from module 'tests.test_cli' is not a Broker." in proc.stdout.read()
+    assert b"Variable 'BrokerHolder.fakebroker' from module 'tests.test_cli' is not a Broker." in proc.stdout.read()


### PR DESCRIPTION
Hi @Bogdanp,

I expected that Dramatiq would be able to resolve deep attribute access like you can define in `pkg_resources` entry-point. This PR add this behaviour, based on pkg_resources implementation ( https://github.com/pypa/setuptools/blob/ad98fcb350fa3ce63389520a391e23274de11064/pkg_resources/__init__.py#L2426-L2434 ).

This ease integration with e.g. Flask by accepting `dramatiq some_module:app.broker` construction.

What do you think of this ?