### PR TITLE
Suggest Flask-Dramatiq extension for Flask integration

### DIFF
--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -238,10 +238,10 @@ build with Django and Dramatiq.
 Flask
 ^^^^^
 
-The `flask_dramatiq_example`_ repo is an example app built with Flask_
-and Dramatiq.
+The `Flask-Dramatiq`_ extension provides extended integration of Dramatiq in
+your Flask_ web app, including configuration and application factory pattern.
 
-.. _flask_dramatiq_example: https://github.com/Bogdanp/flask_dramatiq_example
+.. _Flask-Dramatiq: https://flask-dramatiq.readthedocs.io
 .. _flask: http://flask.pocoo.org
 
 


### PR DESCRIPTION
Hi @Bogdanp,

The [Flask-Dramatiq](https://gitlab.com/bersace/flask-dramatiq) extension is quite ready for more visibility. I suggest to add it to cookbook. For the sake of simplicity, I **replaced** sample app with Flask-Dramatiq extension in documentation. But I can still suggest your sample app if you prefer. Just tell me !

Regards,
Étienne