### PR TITLE
add links to flask-(melo)dramatiq in docs

### DIFF
--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -240,10 +240,12 @@ Flask
 
 The `Flask-Dramatiq`_ extension integrates Dramatiq with Flask_.  It
 includes support for configuration and the application factory
-pattern.
+pattern. `Flask-Melodramatiq`_ is very similar in scope, but tries to
+stay as close as possible to the "native" Dramatiq API.
 
 .. _Flask-Dramatiq: https://flask-dramatiq.readthedocs.io
 .. _flask: http://flask.pocoo.org
+.. _Flask-Melodramatiq: https://flask-melodramatiq.readthedocs.io
 
 
 Operations


### PR DESCRIPTION
Hi. This is a trivial addition of 2 links in the docs.