### PR TITLE
Fix watchdog_gevent import.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,26 +6,27 @@ By adding your name to the list below you disavow any rights or claims
 to any changes submitted to the Dramatiq project and assign copyright
 of those changes to CLEARTYPE SRL.
 
-| Username                                       | Name                   |
-| :-------                                       | :---                   |
-| [@bendemaree](https://github.com/bendemaree)   | Ben Demaree            |
-| [@whalesalad](https://github.com/whalesalad)   | Michael Whalen         |
-| [@rakanalh](https://github.com/rakanalh)       | Rakan Alhneiti         |
-| [@jssuzanne](https://github.com/jssuzanne)     | Jean-Sébastien Suzanne |
-| [@chen2aaron](https://github.com/chen2aaron)   | xixijun                |
-| [@aequitas](https://github.com/aequitas)       | Johan Bloemberg        |
-| [@najamansari](https://github.com/najamansari) | Najam Ahmed Ansari     |
-| [@rpkilby](https://github.com/rpkilby)         | Ryan P Kilby           |
-| [@2miksyn](https://github.com/2miksyn)         | Mikhail Smirnov        |
-| [@gdvalle](https://github.com/gdvalle)         | Greg Dallavalle        |
-| [@viiicky](https://github.com/viiicky)         | Vikas Prasad           |
-| [@xdmiodz](https://github.com/xdmiodz)         | Dmitry Odzerikho       |
-| [@ryansm1](https://github.com/ryansm1)         | Ryan Smith             |
-| [@aericson](https://github.com/aericson)       | André Ericson          |
-| [@maerteijn](https://github.com/maerteijn)     | Martijn Jacobs         |
-| [@ryanhiebert](https://github.com/ryanhiebert) | Ryan Hiebert           |
-| [@davidt99](https://github.com/davidt99)       | davidt99               |
-| [@brownan](https://github.com/brownan)         | Andrew Brown           |
-| [@gilbsgilbs](https://github.com/gilbsgilbs)   | gilbsgilbs             |
-| [@MihaiBalint](https://github.com/MihaiBalint) | Mihai Balint           |
-| [@xelhark](https://github.com/xelhark)         | Gabriele Platania      |
+| Username                                               | Name                   |
+| :-------                                               | :---                   |
+| [@douglasmiranda](https://github.com/douglasmiranda)   | Douglas Miranda        |
+| [@bendemaree](https://github.com/bendemaree)           | Ben Demaree            |
+| [@whalesalad](https://github.com/whalesalad)           | Michael Whalen         |
+| [@rakanalh](https://github.com/rakanalh)               | Rakan Alhneiti         |
+| [@jssuzanne](https://github.com/jssuzanne)             | Jean-Sébastien Suzanne |
+| [@chen2aaron](https://github.com/chen2aaron)           | xixijun                |
+| [@aequitas](https://github.com/aequitas)               | Johan Bloemberg        |
+| [@najamansari](https://github.com/najamansari)         | Najam Ahmed Ansari     |
+| [@rpkilby](https://github.com/rpkilby)                 | Ryan P Kilby           |
+| [@2miksyn](https://github.com/2miksyn)                 | Mikhail Smirnov        |
+| [@gdvalle](https://github.com/gdvalle)                 | Greg Dallavalle        |
+| [@viiicky](https://github.com/viiicky)                 | Vikas Prasad           |
+| [@xdmiodz](https://github.com/xdmiodz)                 | Dmitry Odzerikho       |
+| [@ryansm1](https://github.com/ryansm1)                 | Ryan Smith             |
+| [@aericson](https://github.com/aericson)               | André Ericson          |
+| [@maerteijn](https://github.com/maerteijn)             | Martijn Jacobs         |
+| [@ryanhiebert](https://github.com/ryanhiebert)         | Ryan Hiebert           |
+| [@davidt99](https://github.com/davidt99)               | davidt99               |
+| [@brownan](https://github.com/brownan)                 | Andrew Brown           |
+| [@gilbsgilbs](https://github.com/gilbsgilbs)           | gilbsgilbs             |
+| [@MihaiBalint](https://github.com/MihaiBalint)         | Mihai Balint           |
+| [@xelhark](https://github.com/xelhark)                 | Gabriele Platania      |

--- a/dramatiq/watcher.py
+++ b/dramatiq/watcher.py
@@ -4,7 +4,6 @@ import signal
 
 import watchdog.events
 import watchdog.observers.polling
-import watchdog_gevent
 
 
 def setup_file_watcher(path, use_polling=False):
@@ -15,6 +14,7 @@ def setup_file_watcher(path, use_polling=False):
     if use_polling:
         observer_class = watchdog.observers.polling.PollingObserver
     else:
+        import watchdog_gevent
         observer_class = watchdog_gevent.Observer
 
     file_event_handler = _SourceChangesHandler(patterns=["*.py"])


### PR DESCRIPTION
The late importing of watchdog_gevent will allow us to use, for example,  the polling watcher without having to install watchdog_gevent.

This discussion started here: https://www.reddit.com/r/dramatiq/comments/b72bdo/auto_reload_without_watchdog_gevent/