### PR TITLE
feat(stub): add fail_fast param to StubBroker.join

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,11 +18,15 @@ Added
   error occurs.  (`#179`_, `@davidt99`_)
 * Support for accessing nested broker instances from the CLI.
   (`#191`_, `@bersace`_)
+* Support for eagerly raising actor exceptions in the joining thread
+  with the |StubBroker|.  (`#195`_, `#203`_)
 
 .. _#179: https://github.com/Bogdanp/dramatiq/issues/179
 .. _#183: https://github.com/Bogdanp/dramatiq/issues/183
 .. _#184: https://github.com/Bogdanp/dramatiq/issues/184
 .. _#191: https://github.com/Bogdanp/dramatiq/pull/191
+.. _#195: https://github.com/Bogdanp/dramatiq/issues/195
+.. _#203: https://github.com/Bogdanp/dramatiq/pull/203
 .. _@bersace: https://github.com/bersace
 .. _@davidt99: https://github.com/davidt99
 .. _@xelhark: https://github.com/xelhark

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -470,5 +470,25 @@ Then you can inject and use those fixtures in your tests::
 Because all actors are callable, you can of course also unit test them
 synchronously by calling them as you would normal functions.
 
+Dealing with Exceptions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, any exceptions raised by an actor are raised in the
+worker, which runs in a separate thread from the one your tests run
+in.  This means that any exceptions your actor throws will not be
+visible to your test code!
+
+You can make the stub broker re-raise exceptions from failed actors in your
+main thread by passing ``fail_fast=True`` to its ``join`` method::
+
+  def test_count_words(stub_broker, stub_worker):
+      count_words.send("http://example.com")
+      stub_broker.join(count_words.queue_name, fail_fast=True)
+      stub_worker.join()
+
+This way, whatever exception caused the actor to fail will be raised
+eagerly within your test.  Note that the exception will only be raised
+once the actor exceeds its available retries.
+
 
 .. _pytest fixtures: https://docs.pytest.org/en/latest/fixture.html

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -35,3 +35,34 @@ option is your application will use slighly more memory.
 
 .. _uwsgi: https://uwsgi-docs.readthedocs.io/en/latest
 .. _lazy apps mode: https://uwsgi-docs.readthedocs.io/en/latest/Options.html#lazy-apps
+
+
+Integration Tests Hang
+----------------------
+
+During integration tests, actors are executed in a separate thread
+from the main thread that is running your code, just like they would
+be in the real world.  In that sense, the |StubBroker| is great
+because it helps you simulate real-world execution conditions when
+you're testing your controller code.
+
+The main drawback to this approach is that -- because the actors are
+run in a separate thread -- your testing code has no way of knowing
+when an actor fails so, often, your tests may hang waiting for a
+message to be processed.  An easy way to notice when these types of
+issues occur, is to turn on logging for your tests.  If you use
+pytest_, then you can easily do this from the command line using the
+``--log-cli-level`` flag::
+
+  $ py.test --log-cli-level=warning
+
+You can also pass ``fail_fast=True`` as a parameter to |StubBroker_join|
+in order to make it reraise whatever exception caused the actor to
+fail in the main thread.  Note, however, that the actor is only
+considered to fail once all of its retries have been used up; meaning
+that unless you specify custom retry limits for the actors or for your
+tests as a whole (by configuring the |Retries| middleware), then each
+actor will retry for up to about 30 days before exhausting its
+available retries!
+
+.. _pytest: https://docs.pytest.org/en/latest/

--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -319,6 +319,14 @@ class MessageProxy:
     def __init__(self, message):
         self.failed = False
         self._message = message
+        self._exception = None
+
+    def stuff_exception(self, exception):
+        """Stuff an exception into this message.  Currently, this is
+        used by the stub broker to known why a particular message has
+        failed.
+        """
+        self._exception = exception
 
     def fail(self):
         """Mark this message for rejection.

--- a/dramatiq/brokers/stub.py
+++ b/dramatiq/brokers/stub.py
@@ -1,6 +1,6 @@
 # This file is a part of Dramatiq.
 #
-# Copyright (C) 2017,2018 CLEARTYPE SRL <bogdan@cleartype.io>
+# Copyright (C) 2017,2018,2019 CLEARTYPE SRL <bogdan@cleartype.io>
 #
 # Dramatiq is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -439,6 +439,11 @@ class _WorkerThread(Thread):
             self.broker.emit_after("skip_message", message)
 
         except BaseException as e:
+            # Stuff the exception into the message [proxy] so that it
+            # may be used by the stub broker to provide a nicer
+            # testing experience.
+            message.stuff_exception(e)
+
             if isinstance(e, RateLimitExceeded):
                 self.logger.warning("Rate limit exceeded in message %s: %s.", message, e)
             else:


### PR DESCRIPTION
Closes #195.  This makes it possible to receive the original exception
inside the joining thread.