### PR TITLE
Multiple hosts for RabbitMQ

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,3 +32,4 @@ of those changes to CLEARTYPE SRL.
 | [@bersace](https://github.com/bersace)               | Étienne Bersac         |
 | [@metheoryt](https://github.com/metheoryt)           | Maxim Romanyuk         |
 | [@douglasmiranda](https://github.com/douglasmiranda) | Douglas Miranda        |
+| [@srecnig](https://github.com/srecnig)               | Martin Sereinig        |

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -33,6 +33,27 @@ Redis
 The |RedisBroker| takes a ``namespace`` parameter that you can use to
 logically split queues across multiple apps.
 
+Highly Available Queues
+^^^^^^^^^^^^^^^^^^^^^^^
+
+RabbitMQ
+~~~~~~~~
+
+When running RabbitMQ with a `high availability cluster`_, one can pass
+a sequence of pika `connection parameters`_ to |RabbitmqBroker| when
+instancing it. This will make dramatiq failover if the currently connected
+node fails.
+
+.. code-block:: python
+   from dramatiq.brokers.rabbitmq import RabbitmqBroker
+
+   rabbitmq_broker = RabbitmqBroker(parameters=[
+       dict(host='node1.foo.net'),
+       dict(host='node2.foo.net'),
+   ])
+
+.. _high availability cluster: https://www.rabbitmq.com/ha.html
+.. _connection parameters: https://pika.readthedocs.io/en/0.12.0/modules/parameters.html
 
 Other brokers
 ^^^^^^^^^^^^^

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -66,13 +66,15 @@ class RabbitmqBroker(Broker):
         to this broker.
       max_priority(int): Configure the queues with x-max-priority to
         support priority queue in RabbitMQ itself
-      **parameters(dict): The (pika) connection parameters to use to
+      parameters(list[dict]): A sequence of (pika) connection parameters
+        to determine which Rabbit server(s) to connect to.
+      **kwargs(dict): The (pika) connection parameters to use to
         determine which Rabbit server to connect to.
 
     .. _ConnectionParameters: https://pika.readthedocs.io/en/0.12.0/modules/parameters.html
     """
 
-    def __init__(self, *, confirm_delivery=False, url=None, middleware=None, max_priority=None, **parameters):
+    def __init__(self, *, confirm_delivery=False, url=None, middleware=None, max_priority=None, parameters=None, **kwargs):
         super().__init__(middleware=middleware)
 
         if max_priority is not None and not (0 < max_priority <= 255):
@@ -80,8 +82,10 @@ class RabbitmqBroker(Broker):
 
         if url:
             self.parameters = pika.URLParameters(url)
+        elif parameters:
+            self.parameters = [pika.ConnectionParameters(**p) for p in parameters]
         else:
-            self.parameters = pika.ConnectionParameters(**parameters)
+            self.parameters = pika.ConnectionParameters(**kwargs)
 
         self.confirm_delivery = confirm_delivery
         self.max_priority = max_priority

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -23,6 +23,20 @@ def test_urlrabbitmq_creates_instances_of_rabbitmq_broker():
     assert isinstance(broker, RabbitmqBroker)
 
 
+def test_rabbitmq_broker_can_be_passed_a_list_of_parameters_for_failover():
+    # Given a list of pika connection parameters including an invalid one
+    parameters = [
+        dict(host='127.0.0.1', port=55672), # this will fail
+        dict(host='127.0.0.1'),
+    ]
+
+    # When i pass that to RabbitmqBroker
+    broker = RabbitmqBroker(parameters=parameters)
+
+    # Then I should still get a connection to the host that is up
+    assert broker.connection
+
+
 def test_rabbitmq_actors_can_be_sent_messages(rabbitmq_broker, rabbitmq_worker):
     # Given that I have a database
     database = {}


### PR DESCRIPTION
One can now pass a `parameters` argument to a `RabbitmqBroker` containing a list of connection parameters.

Open questions: 
* Should something like this be possible with URLs, like celery does it, e.g.: `amqps://foo:5672;amqps://bar:5672`? 
* Did i miss anything expect the obvious chores already documented in the contributing document (which i will do once everything is ready) – e.g. should i add this to the docs?
* this test: `test_rabbitmq_actors_can_delay_messages_independent_of_each_other` failed, but to me, it doesn't look like its connected to my change – is this a flaky test, or am i missing something here?