### PR TITLE
Update allowed prometheus-client version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(rel("dramatiq", "__init__.py"), "r") as f:
 
 
 dependencies = [
-    "prometheus-client>=0.2,<0.3",
+    "prometheus-client>=0.2,<0.8",
 ]
 
 extra_dependencies = {


### PR DESCRIPTION
The current version is 0.7.1 and works fine with dramatiq as far as I can see.