### PR TITLE
Add Spawn Flag

### DIFF
--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -163,6 +163,10 @@ def make_argument_parser():
         "--log-file", type=str,
         help="write all logs to a file (default: sys.stderr)",
     )
+    parser.add_argument(
+        "--spawn", action='store_true',
+        help="start processes by spawning (default: fork on unix, spawn on windows"
+    )
 
     if HAS_WATCHDOG:
         parser.add_argument(
@@ -351,6 +355,8 @@ def main(args=None):  # noqa
 
     worker_pipes = []
     worker_processes = []
+    if args.spawn:
+        multiprocessing.set_start_method("spawn")
     for worker_id in range(args.processes):
         read_pipe, write_pipe = multiprocessing.Pipe()
         proc = multiprocessing.Process(


### PR DESCRIPTION
Add a `--spawn` flag to the cli that will allow a user to spawn
processes instead of fork processes if they are on an OS that
defaults to forking processes such as unix based machines.

This started from a conversation on this issue https://github.com/Bogdanp/dramatiq/issues/227
which showed the problem on unix(namely macOS) systems caused by
forking processes.