### PR TITLE
MaxTasksPerChild middleware

### DIFF
--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -369,11 +369,12 @@ def worker_process(args, worker_id, logging_pipe, canteen):
     if worker.restart_requested:
         logger.info("Requesting worker restart.")
     worker.stop()
+    logger.info("Worker stopped.")
     broker.close()
 
     logging_pipe.close()
     if worker.restart_requested:
-        os._exit(RET_RESTART)
+        sys.exit(RET_RESTART)
 
 
 def fork_process(args, fork_id, fork_path, logging_pipe):
@@ -537,8 +538,11 @@ def main(args=None):  # noqa
     while any(p.exitcode in (None, RET_RESTART) for p in worker_processes):
         for proc in list(worker_processes):
             proc.join(timeout=1)
+            logger.debug("Waiting worker with PID %r.", proc.pid)
             if proc.exitcode is None:
+                logger.debug("Waiting with PID %r is running.", proc.pid)
                 continue
+            logger.debug("Worker PID %r finished (code %r).", proc.pid, proc.exitcode)
 
             if proc.exitcode == RET_RESTART and running:
                 logger.debug("Worker with PID %r asking for restart (code %r).", proc.pid, proc.exitcode)
@@ -561,6 +565,10 @@ def main(args=None):  # noqa
 
             else:
                 retcode = max(retcode, proc.exitcode)
+
+    print('Loop exit')
+    for proc in list(worker_processes):
+        print('Worker with PID %r exited with code %r' % (proc.pid, proc.exitcode))
 
     for pipe in [parent_read_pipe, parent_write_pipe, *worker_pipes, *fork_pipes]:
         pipe.close()

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -538,11 +538,8 @@ def main(args=None):  # noqa
     while any(p.exitcode in (None, RET_RESTART) for p in worker_processes):
         for proc in list(worker_processes):
             proc.join(timeout=1)
-            logger.debug("Waiting worker with PID %r.", proc.pid)
             if proc.exitcode is None:
-                logger.debug("Waiting with PID %r is running.", proc.pid)
                 continue
-            logger.debug("Worker PID %r finished (code %r).", proc.pid, proc.exitcode)
 
             if proc.exitcode == RET_RESTART and running:
                 logger.debug("Worker with PID %r asking for restart (code %r).", proc.pid, proc.exitcode)
@@ -565,10 +562,6 @@ def main(args=None):  # noqa
 
             else:
                 retcode = max(retcode, proc.exitcode)
-
-    print('Loop exit')
-    for proc in list(worker_processes):
-        print('Worker with PID %r exited with code %r' % (proc.pid, proc.exitcode))
 
     for pipe in [parent_read_pipe, parent_write_pipe, *worker_pipes, *fork_pipes]:
         pipe.close()

--- a/dramatiq/middleware/max_tasks_per_child.py
+++ b/dramatiq/middleware/max_tasks_per_child.py
@@ -1,0 +1,31 @@
+import threading
+
+from .middleware import Middleware, RestartWorker
+from ..logging import get_logger
+
+# Tasks counter is per worker process
+_tasks_counter = 0
+_tasks_counter_lock = threading.Lock()
+
+
+class MaxTasksPerChild(Middleware):
+    """Middleware that lets you configure the maximum number of tasks a worker can execute
+    before it’s replaced by a new process (like in celery)
+
+    Parameters:
+      max_tasks_per_child(int): Maximum number of tasks a worker process can process before it’s replaced with a new one. Default is no limit.
+    """
+
+    def __init__(self, *, max_tasks_per_child=None):
+        self.logger = get_logger(__name__, type(self))
+        self.max_tasks_per_child = max_tasks_per_child
+
+    def after_process_message(self, broker, message, *, result=None, exception=None):
+        global _tasks_counter
+        self.logger.debug("Processing message, current tasks per child %r.", _tasks_counter)
+        if self.max_tasks_per_child:
+            with _tasks_counter_lock:
+                _tasks_counter += 1
+                if _tasks_counter >= self.max_tasks_per_child:
+                    self.logger.debug("Max tasks per child counter limit reached (%r), restarting worker process.", _tasks_counter)
+                    raise RestartWorker

--- a/dramatiq/middleware/middleware.py
+++ b/dramatiq/middleware/middleware.py
@@ -26,6 +26,11 @@ class SkipMessage(MiddlewareError):
     ``before_process_message`` hook in order to skip a message.
     """
 
+class RestartWorker(MiddlewareError):
+    """An exception that may be raised by Middleware inside the
+    ``after_process_message`` hook in order to restart worker process.
+    """
+
 
 class Middleware:
     """Base class for broker middleware.  The default implementations


### PR DESCRIPTION
In our project, it should be possible to restart workers periodically to free memory after tasks with heavy memory usage.
I did working prototype of MaxTasksPerChild middleware that acts like celery max tasks per child parameter.
If there is interest in such feature in dramatiq i can fix issues if there comments about implementation and write unit test for it.
Will test this code in production environment in next week.