### PR TITLE
feat(abortable): support task abort

### DIFF
--- a/dramatiq/abortable/__init__.py
+++ b/dramatiq/abortable/__init__.py
@@ -1,0 +1,4 @@
+from .backend import EventBackend
+from .middleware import Abort, Abortable
+
+__all__ = ["EventBackend", "Abortable", "Abort"]

--- a/dramatiq/abortable/backend.py
+++ b/dramatiq/abortable/backend.py
@@ -1,0 +1,12 @@
+class EventBackend:
+    """ABC for event backends.
+    """
+
+    def wait_many(self, keys, timeout):  # pragma: no cover
+        raise NotImplementedError
+
+    def poll(self, key):  # pragma: no cover
+        raise NotImplementedError
+
+    def notify(self, key, ttl):  # pragma: no cover
+        raise NotImplementedError

--- a/dramatiq/abortable/backends/__init__.py
+++ b/dramatiq/abortable/backends/__init__.py
@@ -1,0 +1,14 @@
+import warnings
+
+from .stub import StubBackend
+
+try:
+    from .redis import RedisBackend
+except ImportError:  # pragma: no cover
+    warnings.warn(
+        "RedisBackend is not available.  Run `pip install dramatiq[redis]` "
+        "to add support for that backend.", ImportWarning,
+    )
+
+
+__all__ = ["StubBackend", "RedisBackend"]

--- a/dramatiq/abortable/backends/redis.py
+++ b/dramatiq/abortable/backends/redis.py
@@ -1,0 +1,45 @@
+import redis
+
+from ..backend import EventBackend
+
+
+class RedisBackend(EventBackend):
+    """A rate limiter backend for Redis_.
+
+    Parameters:
+      client(Redis): An optional client.  If this is passed,
+        then all other parameters are ignored.
+      url(str): An optional connection URL.  If both a URL and
+        connection paramters are provided, the URL is used.
+      **parameters(dict): Connection parameters are passed directly
+        to :class:`redis.Redis`.
+
+    .. _redis: https://redis.io
+    """
+
+    def __init__(self, *, client=None, url=None, **parameters):
+        if url is not None:
+            parameters["connection_pool"] = redis.ConnectionPool.from_url(url)
+
+        # TODO: Replace usages of StrictRedis (redis-py 2.x) with Redis in Dramatiq 2.0.
+        self.client = client or redis.StrictRedis(**parameters)
+
+    def wait_many(self, keys, timeout):
+        assert timeout is None or timeout >= 1000, "wait timeouts must be >= 1000"
+        event = self.client.blpop(keys, (timeout or 0) // 1000)
+        if event is None:
+            return None
+        key, value = event
+        if value != b"x":
+            return None
+        return key
+
+    def poll(self, key):
+        event = self.client.lpop(key)
+        return event == b"x"
+
+    def notify(self, key, ttl):
+        with self.client.pipeline() as pipe:
+            pipe.rpush(key, b"x")
+            pipe.pexpire(key, ttl)
+            pipe.execute()

--- a/dramatiq/abortable/backends/stub.py
+++ b/dramatiq/abortable/backends/stub.py
@@ -1,0 +1,34 @@
+from threading import Condition
+
+from ..backend import EventBackend
+
+
+class StubBackend(EventBackend):
+    """ABC for rate limiter backends.
+    """
+    def __init__(self):
+        self.condition = Condition()
+        self.events = set()
+
+    def wait_many(self, keys, timeout):
+        with self.condition:
+            if self.condition.wait_for(lambda: self._anyset(keys), timeout=timeout / 1000):
+                for key in keys:
+                    if key in self.events:
+                        self.events.remove(key)
+                        return key
+
+    def poll(self, key):
+        with self.condition:
+            if key in self.events:
+                self.events.remove(key)
+                return True
+        return False
+
+    def notify(self, key, ttl):
+        with self.condition:
+            self.events.add(key)
+            self.condition.notify_all()
+
+    def _anyset(self, keys):
+        return any(k in self.events for k in keys)

--- a/dramatiq/abortable/middleware.py
+++ b/dramatiq/abortable/middleware.py
@@ -75,8 +75,8 @@ class Abortable(Middleware):
 
     after_skip_message = after_process_message
 
-    def abort(self, message):
-        self.backend.notify(self.id_to_key(message.message_id), ttl=self.abort_ttl)
+    def abort(self, message_id):
+        self.backend.notify(self.id_to_key(message_id), ttl=self.abort_ttl)
 
     def _handle(self):
         message_ids = self.abortables.keys()

--- a/dramatiq/abortable/middleware.py
+++ b/dramatiq/abortable/middleware.py
@@ -1,0 +1,115 @@
+import threading
+import time
+import warnings
+from threading import Thread
+
+from ..logging import get_logger
+from ..middleware import Middleware, SkipMessage
+from ..middleware.threading import Interrupt, current_platform, raise_thread_exception, supported_platforms
+
+
+class Abort(Interrupt):
+    """Exception used to interrupt worker threads when their worker
+    processes have been signaled to abort.
+    """
+
+
+class Abortable(Middleware):
+    """Middleware that interrupts actors whose job has been signaled for
+    termination.
+    Currently, this is only available on CPython.
+
+    Note:
+      This works by setting an async exception in the worker thread
+      that runs the actor.  This means that the exception will only get
+      called the next time that thread acquires the GIL.  Concretely,
+      this means that this middleware can't cancel system calls.
+
+    Parameters:
+      abortable(bool): When true, the actor will be interrupted
+        if the task was aborted.
+    """
+    def __init__(self, *, backend, abortable: bool = True):
+        self.logger = get_logger(__name__, type(self))
+        self.abortable = abortable
+        self.backend = backend
+        self.wait_timeout = 1000
+        self.abort_ttl = 90000
+        self.abortables = {}
+        # This lock avoid race between the monitor and a task cleaning up.
+        self.lock = threading.Lock()
+
+    @property
+    def actor_options(self):
+        return {"abortable"}
+
+    def is_abortable(self, actor, message):
+        abortable = message.options.get("abortable")
+        if abortable is None:
+            abortable = actor.options.get("abortable")
+        if abortable is None:
+            abortable = self.abortable
+        return bool(abortable)
+
+    def after_process_boot(self, broker):
+        if current_platform in supported_platforms:
+            thread = Thread(target=self._watcher, daemon=True)
+            thread.start()
+        else:  # pragma: no cover
+            msg = "Abortable cannot kill threads on your current platform (%r)."
+            warnings.warn(msg % current_platform, category=RuntimeWarning, stacklevel=2)
+
+    def before_process_message(self, broker, message):
+        actor = broker.get_actor(message.actor_name)
+        if not self.is_abortable(actor, message):
+            return
+
+        if self.backend.poll(self.id_to_key(message.message_id)):
+            raise SkipMessage()
+
+        self.abortables[message.message_id] = threading.get_ident()
+
+    def after_process_message(self, broker, message, *, result=None, exception=None):
+        with self.lock:
+            self.abortables.pop(message.message_id, None)
+
+    after_skip_message = after_process_message
+
+    def abort(self, message):
+        self.backend.notify(self.id_to_key(message.message_id), ttl=self.abort_ttl)
+
+    def _handle(self):
+        message_ids = self.abortables.keys()
+        if not message_ids:
+            time.sleep(self.wait_timeout / 1000)
+            return
+
+        abort_keys = [self.id_to_key(id_) for id_ in message_ids]
+        key = self.backend.wait_many(abort_keys, self.wait_timeout)
+        if not key:
+            return
+
+        # Trim "abort:".
+        message_id = self.key_to_id(key)
+        with self.lock:
+            thread_id = self.abortables.pop(message_id, None)
+            if thread_id is None:
+                return
+
+            self.logger.info("Aborting task. Raising exception in worker thread %r.", thread_id)
+            raise_thread_exception(thread_id, Abort)
+
+    def _watcher(self):
+        while True:
+            try:
+                self._handle()
+            except Exception:  # pragma: no cover
+                self.logger.exception("Unhandled error while running the time limit handler.")
+
+    @staticmethod
+    def id_to_key(message_id):
+        return ("abort:" + message_id).encode()
+
+    @staticmethod
+    def key_to_id(key):
+        return key.decode()[6:]

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -156,7 +156,7 @@ class Message(namedtuple("Message", (
             else:
                 raise RuntimeError("The default broker doesn't have an abortable backend.")
 
-        middleware.abort(self)
+        middleware.abort(self.message_id)
 
     def __str__(self):
         params = ", ".join(repr(arg) for arg in self.args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from dramatiq.brokers.redis import RedisBroker
 from dramatiq.brokers.stub import StubBroker
 from dramatiq.rate_limits import backends as rl_backends
 from dramatiq.results import backends as res_backends
+from dramatiq.abortable import backends as evt_backends
 
 from .common import RABBITMQ_CREDENTIALS
 
@@ -205,3 +206,29 @@ def result_backends(memcached_result_backend, redis_result_backend, stub_result_
 @pytest.fixture(params=["memcached", "redis", "stub"])
 def result_backend(request, result_backends):
     return result_backends[request.param]
+
+
+@pytest.fixture
+def redis_event_backend():
+    backend = evt_backends.RedisBackend()
+    check_redis(backend.client)
+    backend.client.flushall()
+    return backend
+
+
+@pytest.fixture
+def stub_event_backend():
+    return evt_backends.StubBackend()
+
+
+@pytest.fixture
+def event_backends(redis_event_backend, stub_event_backend):
+    return {
+        "redis": redis_event_backend,
+        "stub": stub_event_backend,
+    }
+
+
+@pytest.fixture(params=["redis", "stub"])
+def event_backend(request, event_backends):
+    return event_backends[request.param]

--- a/tests/test_abortable.py
+++ b/tests/test_abortable.py
@@ -1,0 +1,46 @@
+import time
+
+import pytest
+
+import dramatiq
+from dramatiq.middleware import threading
+from dramatiq.abortable import Abort, Abortable
+
+not_supported = threading.current_platform not in threading.supported_platforms
+
+
+@pytest.mark.skipif(not_supported, reason="Threading not supported on this platform.")
+def test_abort_notifications_are_received(stub_broker, stub_worker, event_backend):
+    # Given that I have a database
+    aborts, successes = [], []
+
+    abortable = Abortable(backend=event_backend)
+    stub_broker.add_middleware(abortable)
+
+    # And an actor that handles shutdown interrupts
+    @dramatiq.actor(abortable=True, max_retries=0)
+    def do_work():
+        try:
+            for _ in range(10):
+                time.sleep(.1)
+        except Abort:
+            aborts.append(1)
+            raise
+        successes.append(1)
+
+    stub_broker.emit_after("process_boot")
+
+    # If I send it a message
+    message = do_work.send()
+
+    # Then wait and signal the task to terminate
+    time.sleep(.1)
+    message.abort()
+
+    # Then join on the queue
+    stub_broker.join(do_work.queue_name)
+    stub_worker.join()
+
+    # I expect it to shutdown
+    assert sum(aborts) == 1
+    assert sum(successes) == 0


### PR DESCRIPTION
This address #51 and #37 .

@Bogdanp, let me know if the design / solution look good to you and I would be willing to work on documentation and tests once the code part is accepted.

In short, each worker has a thread that monitor running tasks and listen to a keyed-event systems. A third-party can abort a task by adding a message id to the keyed-event systems, letting the monitor thread abort the running task using the same method as time-limit middleware or skip a dequeued task.