### PR TITLE
add `receive_in_kwargs` flag

### DIFF
--- a/dramatiq/middleware/pipelines.py
+++ b/dramatiq/middleware/pipelines.py
@@ -50,7 +50,11 @@ class Pipelines(Middleware):
         if message_data is not None:
             next_message = Message(**message_data)
             pipe_ignore = next_message.options.get("pipe_ignore") or actor.options.get("pipe_ignore")
+            pass_as_kwargs = next_message.options.get("pass_as_kwargs") or actor.options.get("pass_as_kwargs")
             if not pipe_ignore:
-                next_message = next_message.copy(args=next_message.args + (result,))
-
+                if pass_as_kwargs:
+                    next_message.kwargs[message.actor_name] = result
+                    next_message = next_message.copy(kwargs=next_message.kwargs)
+                else:
+                    next_message = next_message.copy(args=next_message.args + (result,))
             broker.enqueue(next_message)

--- a/dramatiq/middleware/pipelines.py
+++ b/dramatiq/middleware/pipelines.py
@@ -50,9 +50,9 @@ class Pipelines(Middleware):
         if message_data is not None:
             next_message = Message(**message_data)
             pipe_ignore = next_message.options.get("pipe_ignore") or actor.options.get("pipe_ignore")
-            pass_as_kwargs = next_message.options.get("pass_as_kwargs") or actor.options.get("pass_as_kwargs")
+            receive_in_kwargs = next_message.options.get("receive_in_kwargs") or actor.options.get("receive_in_kwargs")
             if not pipe_ignore:
-                if pass_as_kwargs:
+                if receive_in_kwargs:
                     next_message.kwargs[message.actor_name] = result
                     next_message = next_message.copy(kwargs=next_message.kwargs)
                 else:


### PR DESCRIPTION
When pipelined, It may be useful to pass results of a previous actor to another one within kwargs, with a actor_name as a key. Thus, we can select relative data for sure