### PR TITLE
Fix redis lua script errors 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,3 +37,4 @@ of those changes to CLEARTYPE SRL.
 | [@jonathanlintott](http://github.com/jonathanlintott) | Jonathan Lintott       |
 | [@evstratbg](https://github.com/evstratbg)            | Bogdan Evstratenko     |
 | [@CapedHero](https://github.com/CapedHero)            | Maciej Wrześniewski    |
+| [@benekastah](https://github.com/benekastah)          | Paul Harper            |

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,15 +1,14 @@
 import time
 
 import pytest
-import redis
 
 import dramatiq
+import redis
 from dramatiq import Message, QueueJoinTimeout
 from dramatiq.brokers.redis import MAINTENANCE_SCALE, RedisBroker
 from dramatiq.common import current_millis, dq_name, xq_name
 
 from .common import worker
-
 
 LUA_MAX_UNPACK_SIZE = 7999
 


### PR DESCRIPTION
Calling `unpack` on a list with `7999` items or more causes lua to throw an error (reason why is in the code comments). This will fix errors of that kind in the lua script (primarily encountered in the `do_maintenance` branch).

At least partially fixes #258 (maybe fixes the whole thing; time will tell).