### PR TITLE
Prevent hang when pipe already closed

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,3 +38,4 @@ of those changes to CLEARTYPE SRL.
 | [@evstratbg](https://github.com/evstratbg)            | Bogdan Evstratenko     |
 | [@CapedHero](https://github.com/CapedHero)            | Maciej Wrześniewski    |
 | [@synweap15](https://github.com/synweap15)            | Paweł Werda            |
+| [@asavoy](https://github.com/asavoy)                  | Alvin Savoy            |

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -544,7 +544,12 @@ def main(args=None):  # noqa
                 retcode = max(retcode, proc.exitcode)
 
     for pipe in [parent_read_pipe, parent_write_pipe, *worker_pipes, *fork_pipes]:
-        pipe.close()
+        try:
+            pipe.close()
+        # If the worker process was killed, the handle may already be
+        # closed.
+        except (EOFError, OSError):
+            pass
 
     # The log watcher can't be a daemon in case we log to a file.  So
     # we have to wait for it to complete on exit.  Closing all the


### PR DESCRIPTION
This is a fix for https://github.com/Bogdanp/dramatiq/issues/260

I have verified using the reproducible steps in the issue, that this patch prevents dramatiq hanging when `pipe.close()` raises an OSError.

