### PR TITLE
Fixing delays of messages in a pipeline

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,3 +37,4 @@ of those changes to CLEARTYPE SRL.
 | [@jonathanlintott](http://github.com/jonathanlintott) | Jonathan Lintott       |
 | [@evstratbg](https://github.com/evstratbg)            | Bogdan Evstratenko     |
 | [@CapedHero](https://github.com/CapedHero)            | Maciej Wrześniewski    |
+| [@synweap15](https://github.com/synweap15)            | Paweł Werda            |

--- a/dramatiq/composition.py
+++ b/dramatiq/composition.py
@@ -103,11 +103,14 @@ class pipeline:
 
         Parameters:
           delay(int): The minimum amount of time, in milliseconds, the
-            pipeline should be delayed by.
+            pipeline should be delayed by. If both pipeline's delay and
+            first message's delay are provided, the bigger value will be
+            used.
 
         Returns:
           pipeline: Itself.
         """
+        delay = max(delay or 0, self.messages[0].options.get("delay") or 0) or None
         self.broker.enqueue(self.messages[0], delay=delay)
         return self
 

--- a/dramatiq/middleware/pipelines.py
+++ b/dramatiq/middleware/pipelines.py
@@ -53,4 +53,4 @@ class Pipelines(Middleware):
             if not pipe_ignore:
                 next_message = next_message.copy(args=next_message.args + (result,))
 
-            broker.enqueue(next_message)
+            broker.enqueue(next_message, delay=next_message.options.get("delay"))


### PR DESCRIPTION
Fixes https://github.com/Bogdanp/dramatiq/issues/206.

The delays of messages in the pipeline were ignored, only the `delay` parameter of pipeline's `run` method was taken into consideration.

This PR fixes the handling of delay parameters of messages in a pipeline (first and all following). In addition in alters the behavior of the `delay` parameter of pipeline's `run` method, so that:

1. If there's either a delay specified for the first message or there's a delay specified in pipe run invocation, take the one that's present.
2. If they are both present, take the one that has higher value.