### PR TITLE
[Redis] Fix key error in queued message tracking

### DIFF
--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -302,7 +302,8 @@ class _RedisConsumer(Consumer):
         except redis.ConnectionError as e:
             raise ConnectionClosed(e) from None
         finally:
-            self.queued_message_ids.remove(message.message_id)
+            if message.message_id in self.queued_message_ids:
+                self.queued_message_ids.remove(message.message_id)
 
     def nack(self, message):
         try:
@@ -311,7 +312,8 @@ class _RedisConsumer(Consumer):
         except redis.ConnectionError as e:
             raise ConnectionClosed(e) from None
         finally:
-            self.queued_message_ids.remove(message.message_id)
+            if message.message_id in self.queued_message_ids:
+                self.queued_message_ids.remove(message.message_id)
 
     def requeue(self, messages):
         message_ids = [message.options["redis_message_id"] for message in messages]


### PR DESCRIPTION
I forgot that removing a key from a set that doesn't have that key raises a KeyError.