### PR TITLE
Make queue declaration at RabbitMQ broker lazy

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,3 +40,4 @@ of those changes to CLEARTYPE SRL.
 | [@synweap15](https://github.com/synweap15)            | Paweł Werda            |
 | [@asavoy](https://github.com/asavoy)                  | Alvin Savoy            |
 | [@benekastah](https://github.com/benekastah)          | Paul Harper            |
+| [@timdrijvers](https://github.com/timdrijvers)        | Tim Drijvers           |

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -212,6 +212,28 @@ def test_rabbitmq_actors_can_have_retry_limits(rabbitmq_broker, rabbitmq_worker)
     assert xq_count == 1
 
 
+def test_rabbitmq_broker_doesnot_connect_on():
+    broker = RabbitmqBroker(
+        host="127.0.0.1",
+        max_priority=10,
+        credentials=RABBITMQ_CREDENTIALS,
+    )
+    assert broker.is_connected is False
+    broker.declare_queue("some-queue")
+    assert broker.is_connected is False
+
+
+def test_consume_opens_connection():
+    broker = RabbitmqBroker(
+        host="127.0.0.1",
+        max_priority=10,
+        credentials=RABBITMQ_CREDENTIALS,
+    )
+    assert broker.is_connected is False
+    broker.consume("test-queue", timeout=1)
+    assert broker.is_connected is True
+
+
 def test_rabbitmq_messages_belonging_to_missing_actors_are_rejected(rabbitmq_broker, rabbitmq_worker):
     # Given that I have a broker without actors
     # If I send it a message
@@ -418,14 +440,3 @@ def test_rabbitmq_broker_retries_declaring_queues_when_connection_related_errors
             assert executed
         finally:
             worker.stop()
-
-
-def test_rabbitmq_broker_stops_retrying_declaring_queues_when_max_attempts_reached(rabbitmq_broker):
-    # Given that I have a rabbit instance that lost its connection
-    with patch.object(rabbitmq_broker, "_declare_queue", side_effect=pika.exceptions.AMQPConnectionError):
-        # When I declare an actor
-        # Then a ConnectionClosed error should be raised
-        with pytest.raises(dramatiq.errors.ConnectionClosed):
-            @dramatiq.actor(queue_name="flaky_queue")
-            def do_work():
-                pass


### PR DESCRIPTION
The RabbitMQ broker opens a connection on queue declaration. When task files are being discovered and imported, this causes the actors to register and automatically open a connection. This causes unnecessary connections to be opened, even when no task is being pushed or worker is consuming queues. This PR makes the queue declaration lazy.

Following a discussion: https://www.reddit.com/r/dramatiq/comments/eukrh7/lazy_queue_registration_for_rabbitmq/