### PR TITLE
Emit warning when returning value but not storing results

### DIFF
--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -142,7 +142,14 @@ class Actor:
         try:
             self.logger.debug("Received args=%r kwargs=%r.", args, kwargs)
             start = time.perf_counter()
-            return self.fn(*args, **kwargs)
+            result = self.fn(*args, **kwargs)
+            if result is not None and not self.options.get("store_results", False):
+                self.logger.warning(
+                    "Actor '%s' returns a value that is not None, and you haven't added "
+                    "Results middleware to the broker, which means the return value will be silently dropped. "
+                    "Consider adding Results middleware to your broker." % self.actor_name
+                )
+            return result
         finally:
             delta = time.perf_counter() - start
             self.logger.debug("Completed after %.02fms.", delta * 1000)


### PR DESCRIPTION
This adresses #279. It's a simple solution that will show a warning every time an actor that returns not None value is called, and there's no `store_results=True` (key is missing or it's false) in the actor's configuration.

I was thinking about other options, we could eg. add another middleware that would be always attached and just show warning, but I decided that we can start with the simplest option and let's see what @Bogdanp thinks about it :)