### PR TITLE
Add cli flag to start worker processes with daemon=False

### DIFF
--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -181,6 +181,10 @@ def make_argument_parser():
         help="start processes by spawning (default: fork on unix, spawn on windows)"
     )
     parser.add_argument(
+        "--no-daemon-workers", action="store_true",
+        help="start worker processes with the daemon flag set to False"
+    )
+    parser.add_argument(
         "--fork-function", "-f", action="append", dest="forks", default=[],
         help="fork a subprocess to run the given function"
     )
@@ -424,6 +428,10 @@ def main(args=None):  # noqa
     if args.use_spawn:
         multiprocessing.set_start_method("spawn")
 
+    workers_daemon_flag = True
+    if args.no_daemon_workers:
+        workers_daemon_flag = False
+
     try:
         if args.pid_file:
             setup_pidfile(args.pid_file)
@@ -441,7 +449,7 @@ def main(args=None):  # noqa
         proc = multiprocessing.Process(
             target=worker_process,
             args=(args, worker_id, StreamablePipe(write_pipe), canteen),
-            daemon=True,
+            daemon=workers_daemon_flag,
         )
         proc.start()
         worker_pipes.append(read_pipe)


### PR DESCRIPTION
This allows the use of multiprocessing.Pool inside an actor as discussed in https://www.reddit.com/r/dramatiq/comments/fdus4w/support_for_cpu_intensive_workloads_and/

I initially ran the tests with daemon hardcoded to False and they passed but I made a cli option to reduce any chances altering the current functionality. I furthemore tried to analyze what changes it could create

Since you have already written sighandlers and logic about waiting the worker processes to exit using daemon=False should't leave any orphaned workers assuming cli executes normally and gets shutdowned by signals other than sigkill or sigquit(those also leaves the worker processes orphaned even with daemon=True it could probably only be solved from their side).

If an exception happens in cli before or inside the current process waiting code, it seem to be causing a deadlock in exiting in either way the daemon flag is set.

To conclude if you want to enable actors using multiprocessing I believe that this will cause no harm to existing functionality with either option set. Solving any of the afformentioned issues should probably be tackled in different issues.  I would like to hear your thoughts!

