### PR TITLE
Expose pipe's fileno to StreamablePipe

### DIFF
--- a/dramatiq/compat.py
+++ b/dramatiq/compat.py
@@ -36,6 +36,9 @@ class StreamablePipe:
         self.encoding = encoding
         self.pipe = pipe
 
+    def fileno(self):
+        return self.pipe.fileno()
+
     def flush(self):
         pass
 


### PR DESCRIPTION
If its not exposed any given tasks module that imports libraries that may internally call faulthandler.enable() will produce an exeption

```
AttributeError: 'StreamablePipe' object has no attribute 'fileno'
```

