### PR TITLE
results: store actor failures

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,9 @@ Added
 
 * A custom Redis connection can now be passed to the Redis broker via
   the new ``client`` keyword argument.  (`#274`_, `@davidt99`_)
+* Support for storing actor exceptions.  (`#156`_)
 
+.. _#156: https://github.com/Bogdanp/dramatiq/issues/156
 .. _#274: https://github.com/Bogdanp/dramatiq/issues/274
 .. _@davidt99: https://github.com/davidt99
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -196,3 +196,5 @@ Errors
    :members:
 .. autoclass:: dramatiq.results.ResultTimeout
    :members:
+.. autoclass:: dramatiq.results.ResultFailure
+   :members:

--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -322,9 +322,7 @@ class MessageProxy:
         self._exception = None
 
     def stuff_exception(self, exception):
-        """Stuff an exception into this message.  Currently, this is
-        used by the stub broker to known why a particular message has
-        failed.
+        """Stuff an exception into this message.
         """
         self._exception = exception
 

--- a/dramatiq/results/__init__.py
+++ b/dramatiq/results/__init__.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .backend import Missing, ResultBackend
-from .errors import ResultError, ResultMissing, ResultTimeout
+from .errors import ResultError, ResultFailure, ResultMissing, ResultTimeout
 from .middleware import Results
 
-__all__ = ["Missing", "ResultBackend", "ResultError", "ResultTimeout", "ResultMissing", "Results"]
+__all__ = ["Missing", "ResultBackend", "ResultError", "ResultFailure", "ResultTimeout", "ResultMissing", "Results"]

--- a/dramatiq/results/backends/redis.py
+++ b/dramatiq/results/backends/redis.py
@@ -18,6 +18,7 @@
 import redis
 
 from ..backend import DEFAULT_TIMEOUT, ResultBackend, ResultMissing, ResultTimeout
+from ..result import unwrap_result
 
 
 class RedisBackend(ResultBackend):
@@ -85,7 +86,7 @@ class RedisBackend(ResultBackend):
             if data is None:
                 raise ResultMissing(message)
 
-        return self.encoder.decode(data)
+        return unwrap_result(self.encoder.decode(data))
 
     def _store(self, message_key, result, ttl):
         with self.client.pipeline() as pipe:

--- a/dramatiq/results/errors.py
+++ b/dramatiq/results/errors.py
@@ -31,3 +31,8 @@ class ResultTimeout(ResultError):
 class ResultMissing(ResultError):
     """Raised when a result can't be found.
     """
+
+
+class ResultFailure(ResultError):
+    """Raised when getting a result from an actor that failed.
+    """

--- a/dramatiq/results/result.py
+++ b/dramatiq/results/result.py
@@ -1,0 +1,43 @@
+# This file is a part of Dramatiq.
+#
+# Copyright (C) 2020 CLEARTYPE SRL <bogdan@cleartype.io>
+#
+# Dramatiq is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Dramatiq is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .errors import ResultFailure
+
+# We need to deal with backwards-compatibility here in case the user
+# is migrating between dramatiq versions so the canary is used to
+# detect exception results.
+_CANARY = "dramatiq.results.Result"
+
+
+def wrap_result(res):
+    # This is a no-op for forwards-compatibility.  If the user deploys
+    # a new version of dramatiq and then is forced to roll back, then
+    # this will minimize the fallout.
+    return res
+
+
+def wrap_exception(e):
+    return {
+        "__t": _CANARY,
+        "exn": "actor raised %s: %s" % (type(e).__name__, e),
+    }
+
+
+def unwrap_result(res):
+    if isinstance(res, dict) and res.get("__t") == _CANARY:
+        raise ResultFailure(res["exn"])
+    return res

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -478,7 +478,8 @@ class _WorkerThread(Thread):
         except BaseException as e:
             # Stuff the exception into the message [proxy] so that it
             # may be used by the stub broker to provide a nicer
-            # testing experience.
+            # testing experience.  Also used by the results middleware
+            # to pass exceptions into results.
             message.stuff_exception(e)
 
             if isinstance(e, RateLimitExceeded):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -55,7 +55,7 @@ def test_actors_can_store_exceptions(stub_broker, stub_worker, result_backend):
     stub_broker.add_middleware(Results(backend=result_backend))
 
     # And an actor that stores results
-    @dramatiq.actor(store_results=True)
+    @dramatiq.actor(store_results=True, max_retries=0)
     def do_work():
         raise RuntimeError("failed")
 


### PR DESCRIPTION
Closes #156.  This should be both forwards (mostly) and backwards-compatible.  The only weirdness here is the interaction of failures with retries, but I think I'm fine with leaving the burden on the user to figure that out.