### PR TITLE
fix(rabbitmq): move pika props creation between enqueue callbacks

### DIFF
--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -284,11 +284,6 @@ class RabbitmqBroker(Broker):
         queue_name = message.queue_name
         self.declare_queue(queue_name, ensure=True)
 
-        properties = pika.BasicProperties(
-            delivery_mode=2,
-            priority=message.options.get("broker_priority"),
-        )
-
         if delay is not None:
             queue_name = dq_name(queue_name)
             message_eta = current_millis() + delay
@@ -304,6 +299,10 @@ class RabbitmqBroker(Broker):
             try:
                 self.logger.debug("Enqueueing message %r on queue %r.", message.message_id, queue_name)
                 self.emit_before("enqueue", message, delay)
+                properties = pika.BasicProperties(
+                    delivery_mode=2,
+                    priority=message.options.get("broker_priority"),
+                )
                 self.channel.basic_publish(
                     exchange="",
                     routing_key=queue_name,


### PR DESCRIPTION
Allows to change Pika properties in the `before_enqueue` callback

Closes #290