### PR TITLE
Avoid unnecessary calls to declare_queue on RabbitmqBroker.enqueue()

### DIFF
--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -85,6 +85,8 @@ class Actor:
         """
         for name in ["on_failure", "on_success"]:
             callback = options.get(name)
+            if callback is None:
+                continue
             if isinstance(callback, Actor):
                 options[name] = callback.actor_name
 

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -282,7 +282,8 @@ class RabbitmqBroker(Broker):
             has been closed.
         """
         queue_name = message.queue_name
-        self.declare_queue(queue_name, ensure=True)
+        if queue_name not in self.queues or queue_name in self.queues_pending:
+            self.declare_queue(queue_name, ensure=True)
 
         properties = pika.BasicProperties(
             delivery_mode=2,


### PR DESCRIPTION
## Summary

Enqueuing tasks results in unnecessary calls to declare_queue, this patch aims to avoid those calls (and also adds a minor function call save in Actor.message_with_options).

It's a minor improvement performance-wise, but saving energy is always nice and good for the environment :) 

### Adding 10,000 tasks:

`2644297 function calls (2644200 primitive calls) in 1.940 seconds` (with patch)

vs

`2704295 function calls (2704198 primitive calls) in 2.061 seconds` (without patch)
