### PR TITLE
Facilitate overwriting of Consumer class

### DIFF
--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -109,6 +109,7 @@ class RabbitmqBroker(Broker):
         self.queues = set()
         self.queues_pending = set()
         self.state = local()
+        self.consumer = _RabbitmqConsumer
 
     @property
     def connection(self):
@@ -189,7 +190,7 @@ class RabbitmqBroker(Broker):
           Consumer: A consumer that retrieves messages from RabbitMQ.
         """
         self.declare_queue(queue_name, ensure=True)
-        return _RabbitmqConsumer(self.parameters, queue_name, prefetch, timeout)
+        return self.consumer(self.parameters, queue_name, prefetch, timeout)
 
     def declare_queue(self, queue_name, *, ensure=False):
         """Declare a queue.  Has no effect if a queue with the given

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -109,7 +109,10 @@ class RabbitmqBroker(Broker):
         self.queues = set()
         self.queues_pending = set()
         self.state = local()
-        self.consumer = _RabbitmqConsumer
+
+    @property
+    def consumer_class(self):
+        return _RabbitmqConsumer
 
     @property
     def connection(self):
@@ -190,7 +193,7 @@ class RabbitmqBroker(Broker):
           Consumer: A consumer that retrieves messages from RabbitMQ.
         """
         self.declare_queue(queue_name, ensure=True)
-        return self.consumer(self.parameters, queue_name, prefetch, timeout)
+        return self.consumer_class(self.parameters, queue_name, prefetch, timeout)
 
     def declare_queue(self, queue_name, *, ensure=False):
         """Declare a queue.  Has no effect if a queue with the given

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -117,7 +117,7 @@ class RedisBroker(Broker):
     @property
     def consumer_class(self):
         return _RedisConsumer
-    
+
     def consume(self, queue_name, prefetch=1, timeout=5000):
         """Create a new consumer for a queue.
 

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -21,7 +21,6 @@ import time
 import warnings
 from os import path
 from threading import Lock
-from typing import Any
 from uuid import uuid4
 
 import redis

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -113,6 +113,7 @@ class RedisBroker(Broker):
         # TODO: Replace usages of StrictRedis (redis-py 2.x) with Redis in Dramatiq 2.0.
         self.client = client or redis.StrictRedis(**parameters)
         self.scripts = {name: self.client.register_script(script) for name, script in _scripts.items()}
+        self.consumer = _RedisConsumer
 
     def consume(self, queue_name, prefetch=1, timeout=5000):
         """Create a new consumer for a queue.
@@ -125,7 +126,7 @@ class RedisBroker(Broker):
         Returns:
           Consumer: A consumer that retrieves messages from Redis.
         """
-        return _RedisConsumer(self, queue_name, prefetch, timeout)
+        return self.consumer(self, queue_name, prefetch, timeout)
 
     def declare_queue(self, queue_name):
         """Declare a queue.  Has no effect if a queue with the given

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -21,6 +21,7 @@ import time
 import warnings
 from os import path
 from threading import Lock
+from typing import Any
 from uuid import uuid4
 
 import redis
@@ -113,8 +114,11 @@ class RedisBroker(Broker):
         # TODO: Replace usages of StrictRedis (redis-py 2.x) with Redis in Dramatiq 2.0.
         self.client = client or redis.StrictRedis(**parameters)
         self.scripts = {name: self.client.register_script(script) for name, script in _scripts.items()}
-        self.consumer = _RedisConsumer
 
+    @property
+    def consumer_class(self):
+        return _RedisConsumer
+    
     def consume(self, queue_name, prefetch=1, timeout=5000):
         """Create a new consumer for a queue.
 
@@ -126,7 +130,7 @@ class RedisBroker(Broker):
         Returns:
           Consumer: A consumer that retrieves messages from Redis.
         """
-        return self.consumer(self, queue_name, prefetch, timeout)
+        return self.consumer_class(self, queue_name, prefetch, timeout)
 
     def declare_queue(self, queue_name):
         """Declare a queue.  Has no effect if a queue with the given


### PR DESCRIPTION
This is just a very minor nitpick, feel free to close it, but it would be nice to change the class of the Consumer without the need to completly replicate and overwrite `.consume()` :) 