### PR TITLE
Proposal: build optimized middleware lists per signal, don't execute empty default methods

### DIFF
--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -85,12 +85,11 @@ class Broker:
             self.add_middleware(m)
 
     def _build_optimized_middleware_list(self, signal: str):
-        self.middleware_by_signal[signal] = optimized_list = list()
-        for middleware in self.middleware:
-            middleware_handler = getattr(middleware, signal, False)
-            if middleware_handler is False or hasattr(middleware_handler, "empty"):
-                continue
-            optimized_list.append(middleware_handler)
+        self.middleware_by_signal[signal] = [
+            getattr(middleware, signal)
+            for middleware in self.middleware
+            if callable(getattr(middleware, signal, False)) and not hasattr(getattr(middleware, signal), "noop")
+        ]
 
     def emit_before(self, signal: str, *args, **kwargs):
         signal = "before_" + signal

--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -88,7 +88,7 @@ class Broker:
         self.middleware_by_signal[signal] = optimized_list = list()
         for middleware in self.middleware:
             middleware_handler = getattr(middleware, signal, False)
-            if middleware_handler is False or hasattr(middleware_handler, 'empty'):
+            if middleware_handler is False or hasattr(middleware_handler, "empty"):
                 continue
             optimized_list.append(middleware_handler)
 

--- a/dramatiq/middleware/middleware.py
+++ b/dramatiq/middleware/middleware.py
@@ -49,30 +49,37 @@ class Middleware:
     def before_ack(self, broker, message):
         """Called before a message is acknowledged.
         """
+    before_ack.empty = True
 
     def after_ack(self, broker, message):
         """Called after a message has been acknowledged.
         """
+    after_ack.empty = True
 
     def before_nack(self, broker, message):
         """Called before a message is rejected.
         """
+    before_nack.empty = True
 
     def after_nack(self, broker, message):
         """Called after a message has been rejected.
         """
+    after_nack.empty = True
 
     def before_declare_actor(self, broker, actor):
         """Called before an actor is declared.
         """
+    before_declare_actor.empty = True
 
     def after_declare_actor(self, broker, actor):
         """Called after an actor has been declared.
         """
+    after_declare_actor.empty = True
 
     def before_declare_queue(self, broker, queue_name):
         """Called before a queue is declared.
         """
+    before_declare_queue.empty = True
 
     def after_declare_queue(self, broker, queue_name):
         """Called after a queue has been declared.
@@ -83,22 +90,27 @@ class Middleware:
         queues when actors are created, but it doesn't instantiate
         them until messages are enqueued or consumed.
         """
+    after_declare_queue.empty = True
 
     def after_declare_delay_queue(self, broker, queue_name):
         """Called after a delay queue has been declared.
         """
+    after_declare_delay_queue.empty = True
 
     def before_enqueue(self, broker, message, delay):
         """Called before a message is enqueued.
         """
+    before_enqueue.empty = True
 
     def after_enqueue(self, broker, message, delay):
         """Called after a message has been enqueued.
         """
+    after_enqueue.empty = True
 
     def before_delay_message(self, broker, message):
         """Called before a message has been delayed in worker memory.
         """
+    before_delay_message.empty = True
 
     def before_process_message(self, broker, message):
         """Called before a message is processed.
@@ -108,35 +120,43 @@ class Middleware:
             this is raised, ``after_skip_message`` is emitted instead
             of ``after_process_message``.
         """
+    before_process_message.empty = True
 
     def after_process_message(self, broker, message, *, result=None, exception=None):
         """Called after a message has been processed.
         """
+    after_process_message.empty = True
 
     def after_skip_message(self, broker, message):
         """Called instead of ``after_process_message`` after a message
         has been skippped.
         """
+    after_skip_message.empty = True
 
     def after_process_boot(self, broker):
         """Called immediately after subprocess start up.
         """
+    after_process_boot.empty = True
 
     def before_worker_boot(self, broker, worker):
         """Called before the worker process starts up.
         """
+    before_worker_boot.empty = True
 
     def after_worker_boot(self, broker, worker):
         """Called after the worker process has started up.
         """
+    after_worker_boot.empty = True
 
     def before_worker_shutdown(self, broker, worker):
         """Called before the worker process shuts down.
         """
+    before_worker_shutdown.empty = True
 
     def after_worker_shutdown(self, broker, worker):
         """Called after the worker process shuts down.
         """
+    after_worker_shutdown.empty = True
 
     def before_consumer_thread_shutdown(self, broker, thread):
         """Called before a consumer thread shuts down.  This may be
@@ -145,6 +165,7 @@ class Middleware:
 
         There is no ``after_consumer_thread_boot``.
         """
+    before_consumer_thread_shutdown.empty = True
 
     def before_worker_thread_shutdown(self, broker, thread):
         """Called before a worker thread shuts down.  This may be used
@@ -153,3 +174,4 @@ class Middleware:
 
         There is no ``after_worker_thread_boot``.
         """
+    before_worker_thread_shutdown.empty = True

--- a/dramatiq/middleware/middleware.py
+++ b/dramatiq/middleware/middleware.py
@@ -49,37 +49,37 @@ class Middleware:
     def before_ack(self, broker, message):
         """Called before a message is acknowledged.
         """
-    before_ack.empty = True
+    before_ack.noop = True
 
     def after_ack(self, broker, message):
         """Called after a message has been acknowledged.
         """
-    after_ack.empty = True
+    after_ack.noop = True
 
     def before_nack(self, broker, message):
         """Called before a message is rejected.
         """
-    before_nack.empty = True
+    before_nack.noop = True
 
     def after_nack(self, broker, message):
         """Called after a message has been rejected.
         """
-    after_nack.empty = True
+    after_nack.noop = True
 
     def before_declare_actor(self, broker, actor):
         """Called before an actor is declared.
         """
-    before_declare_actor.empty = True
+    before_declare_actor.noop = True
 
     def after_declare_actor(self, broker, actor):
         """Called after an actor has been declared.
         """
-    after_declare_actor.empty = True
+    after_declare_actor.noop = True
 
     def before_declare_queue(self, broker, queue_name):
         """Called before a queue is declared.
         """
-    before_declare_queue.empty = True
+    before_declare_queue.noop = True
 
     def after_declare_queue(self, broker, queue_name):
         """Called after a queue has been declared.
@@ -90,27 +90,27 @@ class Middleware:
         queues when actors are created, but it doesn't instantiate
         them until messages are enqueued or consumed.
         """
-    after_declare_queue.empty = True
+    after_declare_queue.noop = True
 
     def after_declare_delay_queue(self, broker, queue_name):
         """Called after a delay queue has been declared.
         """
-    after_declare_delay_queue.empty = True
+    after_declare_delay_queue.noop = True
 
     def before_enqueue(self, broker, message, delay):
         """Called before a message is enqueued.
         """
-    before_enqueue.empty = True
+    before_enqueue.noop = True
 
     def after_enqueue(self, broker, message, delay):
         """Called after a message has been enqueued.
         """
-    after_enqueue.empty = True
+    after_enqueue.noop = True
 
     def before_delay_message(self, broker, message):
         """Called before a message has been delayed in worker memory.
         """
-    before_delay_message.empty = True
+    before_delay_message.noop = True
 
     def before_process_message(self, broker, message):
         """Called before a message is processed.
@@ -120,43 +120,43 @@ class Middleware:
             this is raised, ``after_skip_message`` is emitted instead
             of ``after_process_message``.
         """
-    before_process_message.empty = True
+    before_process_message.noop = True
 
     def after_process_message(self, broker, message, *, result=None, exception=None):
         """Called after a message has been processed.
         """
-    after_process_message.empty = True
+    after_process_message.noop = True
 
     def after_skip_message(self, broker, message):
         """Called instead of ``after_process_message`` after a message
         has been skippped.
         """
-    after_skip_message.empty = True
+    after_skip_message.noop = True
 
     def after_process_boot(self, broker):
         """Called immediately after subprocess start up.
         """
-    after_process_boot.empty = True
+    after_process_boot.noop = True
 
     def before_worker_boot(self, broker, worker):
         """Called before the worker process starts up.
         """
-    before_worker_boot.empty = True
+    before_worker_boot.noop = True
 
     def after_worker_boot(self, broker, worker):
         """Called after the worker process has started up.
         """
-    after_worker_boot.empty = True
+    after_worker_boot.noop = True
 
     def before_worker_shutdown(self, broker, worker):
         """Called before the worker process shuts down.
         """
-    before_worker_shutdown.empty = True
+    before_worker_shutdown.noop = True
 
     def after_worker_shutdown(self, broker, worker):
         """Called after the worker process shuts down.
         """
-    after_worker_shutdown.empty = True
+    after_worker_shutdown.noop = True
 
     def before_consumer_thread_shutdown(self, broker, thread):
         """Called before a consumer thread shuts down.  This may be
@@ -165,7 +165,7 @@ class Middleware:
 
         There is no ``after_consumer_thread_boot``.
         """
-    before_consumer_thread_shutdown.empty = True
+    before_consumer_thread_shutdown.noop = True
 
     def before_worker_thread_shutdown(self, broker, thread):
         """Called before a worker thread shuts down.  This may be used
@@ -174,4 +174,4 @@ class Middleware:
 
         There is no ``after_worker_thread_boot``.
         """
-    before_worker_thread_shutdown.empty = True
+    before_worker_thread_shutdown.noop = True


### PR DESCRIPTION
After digging a little deeper into the call graph I identified some additional calling overhead that can be optimized :slightly_smiling_face: 

#### Benchmark (adding 10,000 tasks):

without patch:
2704295 function calls(2704198 primitive calls) in 1.925 seconds

with patch:
2474322 function calls (2474225 primitive calls) in 1.713 seconds