### PR TITLE
ci: add 3.8 to build matrix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - run: pip install tox
       - run: tox -e lint
 
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-18.04"]
-        python: ["3.5", "3.6", "3.7"]
+        python: ["3.5", "3.6", "3.7", "3.8"]
 
     runs-on: ${{ matrix.os }}
     name: test on ${{ matrix.python }} (${{ matrix.os }})
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-2016"]
-        python: ["3.5", "3.6", "3.7"]
+        python: ["3.5", "3.6", "3.7", "3.8"]
 
     runs-on: ${{ matrix.os }}
     name: test on ${{ matrix.python }} (${{ matrix.os }})


### PR DESCRIPTION
Blocked by a lack of memcached wheels for 3.8.