### PR TITLE
Replace `message ~= nil` in dispatch.lua, since a negative result returns false and not nil

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,3 +42,4 @@ of those changes to CLEARTYPE SRL.
 | [@benekastah](https://github.com/benekastah)          | Paul Harper            |
 | [@timdrijvers](https://github.com/timdrijvers)        | Tim Drijvers           |
 | [@takhs91](https://github.com/takhs91)                | Takis Panagopoulos     |
+| [@swidoff](https://github.com/swidoff)                | Seth Widoff            |

--- a/dramatiq/brokers/redis/dispatch.lua
+++ b/dramatiq/brokers/redis/dispatch.lua
@@ -213,7 +213,7 @@ elseif command == "nack" then
 
     -- then pop it off the messages hash and move it onto the DLQ
     local message = redis.call("hget", queue_messages, message_id)
-    if message ~= nil then
+    if message then
         redis.call("zadd", xqueue_full_name, timestamp, message_id)
         redis.call("hset", xqueue_messages, message_id, message)
         redis.call("hdel", queue_messages, message_id)

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -336,7 +336,7 @@ def test_redis_broker_warns_about_deprecated_parameters():
         RedisBroker(requeue_deadline=1000)
 
     assert str(record[0].message) == \
-           "requeue_{deadline,interval} have been deprecated and no longer do anything"
+        "requeue_{deadline,interval} have been deprecated and no longer do anything"
 
 
 def test_redis_broker_raises_attribute_error_when_given_an_invalid_attribute(redis_broker):

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -336,7 +336,7 @@ def test_redis_broker_warns_about_deprecated_parameters():
         RedisBroker(requeue_deadline=1000)
 
     assert str(record[0].message) == \
-        "requeue_{deadline,interval} have been deprecated and no longer do anything"
+           "requeue_{deadline,interval} have been deprecated and no longer do anything"
 
 
 def test_redis_broker_raises_attribute_error_when_given_an_invalid_attribute(redis_broker):
@@ -461,3 +461,30 @@ def test_redis_consumer_nack_can_retry_on_connection_error(redis_broker, redis_w
         assert nack_mock.call_count >= 2
         # And I expect there to be no outstanding messages
         assert consumer.outstanding_message_count == 0
+
+
+def test_redis_consumer_nack_does_not_raise_on_missing_id(redis_worker):
+    """
+    Reproduces issue 320, exception when the message id is not found.
+
+    https://github.com/Bogdanp/dramatiq/issues/320
+
+    Before the change would raise:
+    redis.exceptions.ResponseError: Error running script (call to f_e9668bc413bd4a2d63c8108b124f5b7df0d01263):
+    @user_script:218: @user_script: 218: Lua redis() command arguments must be strings or integers
+    """
+    # Given that I have an actor
+    @dramatiq.actor(max_retries=0)
+    def do_work():
+        raise RuntimeError
+
+    consumer = redis_worker.consumers[do_work.queue_name].consumer
+
+    # If I send a bogus message to nack, I expect no exception to be raised.
+    message = Message(
+        queue_name=do_work.queue_name,
+        actor_name=do_work.actor_name,
+        args=(), kwargs={},
+        options={"redis_message_id": "XXXXXXXXX"}
+    )  # Bogus ID
+    consumer.nack(message)


### PR DESCRIPTION
This is a fix for [issue 320](https://github.com/Bogdanp/dramatiq/issues/320).

Apparently, `redis.call("hget"...)` doesn't return nil if the key does not exist, it returns false.

Here's an example script I wrote:

```
local queue = "test-queue"
local message_id1 = "key"
local message_id2 = "not-a-key"

redis.call("hset", queue, message_id1, "value")

local message1 = redis.call("hget", queue, message_id1)
local message2 = redis.call("hget", queue, message_id2)

redis.debug(message1)
redis.debug(message2)

if message1 ~= nil then
   redis.debug("Message 1 is not nil with ~=")
end

if message1 then
   redis.debug("Message 1 is not nil")
end

if message2 ~= nil then
   redis.debug("Message 2 is not nil with ~=")
end

if message2 then
   redis.debug("Message 2 is not nil")
end
```

The output is:

```
 redis-cli --ldb --eval test.lua 
Lua debugging session started, please use:
quit    -- End the session.
restart -- Restart the script in debug mode again.
help    -- Show Lua script debugging commands.

14882:C 27 Jun 2020 00:38:42.506 # Redis forked for debugging eval
* Stopped at 1, stop reason = step over
-> 1   local queue = "test-queue"
lua debugger> c
14882:C 27 Jun 2020 00:38:42.977 # Lua debugging session child exiting
<debug> line 10: "value"
<debug> line 11: false
<debug> line 14: "Message 1 is not nil with ~="
<debug> line 18: "Message 1 is not nil"
<debug> line 22: "Message 2 is not nil with ~="
```

The second `hget` of an unmapped key returns false and so the result will always be not nil.