### PR TITLE
Raise an error if watch is used on an unsupported system.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,3 +43,4 @@ of those changes to CLEARTYPE SRL.
 | [@timdrijvers](https://github.com/timdrijvers)        | Tim Drijvers           |
 | [@takhs91](https://github.com/takhs91)                | Takis Panagopoulos     |
 | [@swidoff](https://github.com/swidoff)                | Seth Widoff            |
+| [@CaselIT](https://github.com/CaselIT)                | Federico Caselli       |

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,7 +35,7 @@ Name           Description
 ``memcached``  Installs the required dependencies for the Memcached rate limiter backend.
 ``rabbitmq``   Installs the required dependencies for using Dramatiq with RabbitMQ.
 ``redis``      Installs the required dependencies for using Dramatiq with Redis.
-``watch``      Installs the required dependencies for the ``--watch`` flag.
+``watch``      Installs the required dependencies for the ``--watch`` flag. (Supported only on unix)
 =============  =======================================================================================
 
 If you want to install Dramatiq with all available features, run::

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -190,7 +190,8 @@ def make_argument_parser():
             "--watch", type=folder_path, metavar="DIR",
             help=(
                 "watch a directory and reload the workers when any source files "
-                "change (this feature must only be used during development)"
+                "change (this feature must only be used during development). "
+                "This option is currently only supproted on unix systems."
             )
         )
         parser.add_argument(
@@ -496,6 +497,8 @@ def main(args=None):  # noqa
         )
 
     if HAS_WATCHDOG and args.watch:
+        if not hasattr(signal, "SIGHUP"):
+            raise RuntimeError("The watch option is currently not supported on this platform.")
         file_watcher = setup_file_watcher(args.watch, args.watch_use_polling)
 
     log_watcher_stop_event = Event()


### PR DESCRIPTION
Fixes #326

I'm not sure if / how should this be tested. Currently all cli test are skipped on windows.