### PR TITLE
Worker timeout option

### DIFF
--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -185,7 +185,7 @@ def make_argument_parser():
         help="fork a subprocess to run the given function"
     )
     parser.add_argument(
-        "--worker-shutdown-time-limit", type=int, default="600_000",
+        "--worker-shutdown-time-limit", type=int, default=600000,
         help="time limit for worker shutdown, in milliseconds (default: 10 minutes)"
     )
 

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -184,6 +184,10 @@ def make_argument_parser():
         "--fork-function", "-f", action="append", dest="forks", default=[],
         help="fork a subprocess to run the given function"
     )
+    parser.add_argument(
+        "--worker-shutdown-time-limit", type=int, default="600_000",
+        help="time limit for worker shutdown, in milliseconds (default: 10 minutes)"
+    )
 
     if HAS_WATCHDOG:
         parser.add_argument(
@@ -378,7 +382,7 @@ def worker_process(args, worker_id, logging_pipe, canteen, event):
     while running:
         time.sleep(1)
 
-    worker.stop()
+    worker.stop(timeout=args.worker_shutdown_time_limit)
     broker.close()
     logging_pipe.close()
 


### PR DESCRIPTION
Currently when doing graceful shutdown of dramatiq, there is 10 minutes timeout for workers. That means that any worker computing longer than 10 minutes will be terminated. This PR adds an option to set this timeout on command-line, so longer workloads will not be terminated by graceful shutdown.