### PR TITLE
Don't allow Result middleware without a result backend.

### DIFF
--- a/dramatiq/results/backend.py
+++ b/dramatiq/results/backend.py
@@ -21,7 +21,7 @@ import typing
 
 from ..common import compute_backoff, q_name
 from ..encoder import Encoder
-from .errors import ResultMissing, ResultTimeout, ResultError
+from .errors import ResultMissing, ResultTimeout
 from .result import unwrap_result, wrap_exception, wrap_result
 
 #: The default timeout for blocking get operations in milliseconds.

--- a/dramatiq/results/backend.py
+++ b/dramatiq/results/backend.py
@@ -21,7 +21,7 @@ import typing
 
 from ..common import compute_backoff, q_name
 from ..encoder import Encoder
-from .errors import ResultMissing, ResultTimeout
+from .errors import ResultMissing, ResultTimeout, ResultError
 from .result import unwrap_result, wrap_exception, wrap_result
 
 #: The default timeout for blocking get operations in milliseconds.

--- a/dramatiq/results/middleware.py
+++ b/dramatiq/results/middleware.py
@@ -14,9 +14,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from . import ResultError
 from ..logging import get_logger
 from ..middleware import Middleware
+from .errors import ResultError
 
 #: The maximum amount of milliseconds results are allowed to exist in
 #: the backend.

--- a/dramatiq/results/middleware.py
+++ b/dramatiq/results/middleware.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+from . import ResultError
 from ..logging import get_logger
 from ..middleware import Middleware
 
@@ -69,6 +69,13 @@ class Results(Middleware):
 
     def __init__(self, *, backend=None, store_results=False, result_ttl=None):
         self.logger = get_logger(__name__, type(self))
+
+        # forbid result middleware without a result backend
+        if backend is None:
+            raise ResultError("Creating a result middleware without a result backend is not allowed!"
+                              "If you are using django_dramatiq: don't add this middleware to the "
+                              "broker's middleware list, just define DRAMATIQ_RESULT_BACKEND. ")
+
         self.backend = backend
         self.store_results = store_results
         self.result_ttl = result_ttl or DEFAULT_RESULT_TTL


### PR DESCRIPTION
Since I saw some issues related to the result middleware and django_dramatiq lately, I think it might be sensible to be more strict and descriptive when using the result middleware the wrong way.

My first idea was to use a fallback call like `get_broker`, but this would also require changes to `django_dramatiq` which needs to set the backend first, but it's currently **way** too hot to be really productive and motivated, so raising an descriptive error was my next idea :upside_down_face: 

Feel free to adjust the error message, on a second read it sounds a bit harsh.