### PR TITLE
ci: Add Python 3.8

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - run: pip install tox
       - run: tox -e lint
 
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-18.04"]
-        python: ["3.5", "3.6", "3.7"]
+        python: ["3.5", "3.6", "3.7", "3.8"]
 
     runs-on: ${{ matrix.os }}
     name: test on ${{ matrix.python }} (${{ matrix.os }})
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-2016"]
-        python: ["3.5", "3.6", "3.7"]
+        python: ["3.5", "3.6", "3.7", "3.8"]
 
     runs-on: ${{ matrix.os }}
     name: test on ${{ matrix.python }} (${{ matrix.os }})

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
+      - run: sudo apt-get update -qq && sudo apt-get install -y libmemcached-dev
       - run: pip install -e '.[dev]'
       - run: py.test --benchmark-skip
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -89,7 +89,7 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           set INCLUDE=%cd%\..;%INCLUDE%
           msbuild libmemcached.vcxproj /p:UseEnv=true /p:Configuration=Release /t:Build;CopyFiles
-          cp Lib\memcached.dll ..\..\
+          cp Lib\memcached.dll %WINDIR%\system32
           pip install --install-option="--without-zlib" --install-option="--with-libmemcached=%cd%" pylibmc
         shell: cmd
         working-directory: libmemcached\win32

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,3 +46,4 @@ of those changes to CLEARTYPE SRL.
 | [@CaselIT](https://github.com/CaselIT)                | Federico Caselli       |
 | [@omegacoleman](https://github.com/omegacoleman)      | You Cai                |
 | [@denhai](https://github.com/denhai)                  | Hayden Bartlett        |
+| [@rouge8](https://github.com/rouge8)                  | Andy Freeland          |

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,6 @@ envlist=
 [testenv]
 extras=
   dev
-deps=
-  lint: isort
-        flake8
-        flake8-bugbear
-        flake8-quotes
 commands=
   py.test --benchmark-skip {posargs}
 passenv=
@@ -24,6 +19,12 @@ commands=
   make html
 
 [testenv:lint]
+extras =
+deps =
+  isort
+  flake8
+  flake8-bugbear
+  flake8-quotes
 commands=
   flake8 {toxinidir}/dramatiq {toxinidir}/examples {toxinidir}/tests
   isort -c dramatiq

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-  py{35,36,37}-cpython
+  py{35,36,37,38}-cpython
   docs
   lint
 


### PR DESCRIPTION
Closes #318.

I also did some tox cleanup so that we wouldn't need to install libmemcached-dev to run `tox -e lint`.

The Windows changes are because of https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew