### PR TITLE
Fix memory leak in dramatiq.Worker:process_message

### DIFF
--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -500,6 +500,12 @@ class _WorkerThread(Thread):
             self.consumers[message.queue_name].post_process_message(message)
             self.work_queue.task_done()
 
+            # NOTE: Since access to the `_exception` attribute is no longer
+            # necessary, clear it in order to prevent memory leakage due to
+            # cyclic references created between the exception object and local
+            # variable `message` that's already present in the stack frame.
+            message._exception = None
+
     def pause(self):
         """Pause this worker.
         """


### PR DESCRIPTION
The memory leak takes place **only** when an exception is thrown.

The problem has been traced down to the exception handler of
`process_message` and more specifically to how the exception
object is handled and stored in order to be referred back to
down the road, eg. for debugging purposes or by the results'
middleware. When `message.stuff_exception(e)` is called, a
cyclic reference is created, which causes objects to not be
garbage-collected (at least not until the cyclic GC kicks in).

In general, a cyclic reference is created when the exception
object is stored in a variable x, which is part of the stack
frame. The exception object references the stack frame, thus
the variable x, via its `__traceback__` attribute. But now x
references the exception object, too, thus the stack frame.
So, a cyclic reference is created!

In this particular case, the reference cycle created is:

  message -> message._exception -> e -> stackframe -> message

In general, it is not recommended to store exception objects
in local vars. However, if that's necessary, such variables
should always be (explicitly) cleared in order to break the
cyclic reference - usually in a try/finally statement.

In that sense, it comes in handy that a try/finally statement
is already being used. By setting `message._exception` to `None`
at the very end the reference cycle is broken and objects are
garbage-collected soon enough.

The following piece of code can be used to re-produce the problem:

```python
import dramatiq


@dramatiq.actor
def foo(*args, **kwargs):
    a = tuple(range(5000000))                                        
    raise Exception('bar')                                                      
```

After running `for _ in range(5): foo.send()` the memory leak is evident:

![Figure_1](https://user-images.githubusercontent.com/17277103/95971787-53a20e00-0e1a-11eb-80ee-a567b47d7169.png)

When the fix is applied:

![Figure_1_no_leak](https://user-images.githubusercontent.com/17277103/95971800-5866c200-0e1a-11eb-8963-c3a0f3340bdf.png)