### PR TITLE
res: allow to overwrite unwrap_results()

### DIFF
--- a/dramatiq/results/backends/redis.py
+++ b/dramatiq/results/backends/redis.py
@@ -86,7 +86,10 @@ class RedisBackend(ResultBackend):
             if data is None:
                 raise ResultMissing(message)
 
-        return unwrap_result(self.encoder.decode(data))
+        return self.unwrap_result(self.encoder.decode(data))
+
+    def unwrap_result(self, res):
+        return unwrap_result(res)
 
     def _store(self, message_key, result, ttl):
         with self.client.pipeline() as pipe:


### PR DESCRIPTION
As I am moving some existing code into workers I want my backtraces to be raised as if they were in process.

A quick hack with tblib seems to work fine, but I have to overwrite the complete `RedisBackend.get_result`. If `RedisBackend.unwrap_result` would exist I could simply do something like this:

```python
class ExceptionPicklingRdisBackend(dramatiq.results.backends.RedisBackend):
    def store_exception(self, message, exception: Exception, ttl: int) -> None:
        tblib.pickling_support.install()

        message_key = self.build_message_key(message)
        return self._store(message_key, exception, ttl)

    def unwrap_result(self, res):
        tblib.pickling_support.install()

        if isinstance(res, BaseException):
            raise res

        return super().unwrap_result(res)
```