### PR TITLE
ci: fix memcached for windows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -91,9 +91,9 @@ jobs:
       - name: Install memcached
         run: |
           mkdir memcached
-          Invoke-WebRequest "https://s3.amazonaws.com/downloads.northscale.com/memcached-win64-1.4.4-14.zip" -OutFile "memcached\memcached.zip"
-          7z x memcached\memcached.zip -y -omemcached\
-          Start-Process memcached\memcached\memcached.exe -PassThru
+          Invoke-WebRequest "https://github.com/jefyt/memcached-windows/releases/download/1.6.8_mingw/memcached-1.6.7-win32-mingw.zip" -OutFile "memcached\memcached.zip"
+          7z x memcached\memcached.zip -y -omemcached
+          Start-Process memcached\memcached-1.6.7-win32-mingw\bin\memcached.exe -PassThru
 
       - name: Install RabbitMQ and Redis
         run: |


### PR DESCRIPTION
This addresses broken tests in the CI env by using a native port of
memcached for the test suite... I'm not sure if it's crashing, or unable
to handle the load from the test suite, but the native copy seems to
do fine.

Fixes https://github.com/Bogdanp/dramatiq/issues/370.