### PR TITLE
logging: omit result warning with piped messages

### DIFF
--- a/dramatiq/results/middleware.py
+++ b/dramatiq/results/middleware.py
@@ -93,7 +93,9 @@ class Results(Middleware):
         store_results, result_ttl = self._lookup_options(broker, message)
         if store_results and exception is None:
             self.backend.store_result(message, result, result_ttl)
-        if not store_results and result is not None:
+        if not store_results \
+           and result is not None \
+           and message.options.get("pipe_target") is None:
             self.logger.warning(
                 "Actor '%s' returned a value that is not None, but you "
                 "haven't set its `store_results' option to `True' so "


### PR DESCRIPTION
This avoids the Results middleware's warning about a return value that
isn't stored when piped messages are used.

The actor's warning about returning results already has this behavior,
but it felt like we should avoid the log message for piped messages w/
Results middleware too.