### PR TITLE
fix: handle decode errors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -47,3 +47,4 @@ of those changes to CLEARTYPE SRL.
 | [@omegacoleman](https://github.com/omegacoleman)      | You Cai                |
 | [@denhai](https://github.com/denhai)                  | Hayden Bartlett        |
 | [@rouge8](https://github.com/rouge8)                  | Andy Freeland          |
+| [@thomazthz](https://github.com/thomazthz)            | Thomaz Soares          |

--- a/dramatiq/errors.py
+++ b/dramatiq/errors.py
@@ -27,6 +27,11 @@ class DramatiqError(Exception):  # pragma: no cover
         return str(self.message) or repr(self.message)
 
 
+class DecodeError(DramatiqError):
+    """Raised when a message fails to decode.
+    """
+
+
 class BrokerError(DramatiqError):
     """Base class for broker-related errors.
     """

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -22,6 +22,7 @@ from collections import namedtuple
 from .broker import get_broker
 from .composition import pipeline
 from .encoder import Encoder, JSONEncoder
+from .errors import DecodeError
 from .results import Results
 
 #: The global encoder instance.
@@ -93,7 +94,10 @@ class Message(namedtuple("Message", (
     def decode(cls, data):
         """Convert a bytestring to a message.
         """
-        return cls(**global_encoder.decode(data))
+        try:
+            return cls(**global_encoder.decode(data))
+        except Exception as e:
+            raise DecodeError("Failed to decode message: %s" % data) from e
 
     def encode(self):
         """Convert this message to a bytestring.

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -458,3 +458,35 @@ def test_rabbitmq_broker_retries_declaring_queues_when_connection_related_errors
             assert executed
         finally:
             worker.stop()
+
+
+def test_rabbitmq_messages_that_failed_to_decode_are_rejected(rabbitmq_broker, rabbitmq_worker):
+    # Given that I have an Actor
+    @dramatiq.actor(max_retries=0)
+    def do_work(_):
+        pass
+
+    # And an encoder that may fail to decode
+    def decode(self, data):
+        if "xfail" in str(data):
+            raise RuntimeError("xfail")
+        return self.super().decode(data)
+
+    old_encoder = dramatiq.get_encoder()
+    new_encoder = type("_Encoder", (old_encoder.__class__,), {"decode": decode})
+    dramatiq.set_encoder(new_encoder())
+
+    # When I send a message that will fail to decode
+    do_work.send("xfail")
+
+    # And I join on the queue
+    rabbitmq_broker.join(do_work.queue_name)
+    rabbitmq_worker.join()
+
+    # Then I expect the message to get moved to the dead letter queue
+    q_count, dq_count, xq_count = rabbitmq_broker.get_queue_message_counts(do_work.queue_name)
+
+    assert q_count == dq_count == 0
+    assert xq_count == 1
+
+    dramatiq.set_encoder(old_encoder)


### PR DESCRIPTION
I noticed that the worker consumer thread hangs indefinitely when an exception is raised from the message decoder. The consumer does not know how to handle it because the message has not been created yet.

So it enters in the loop:

1. Tries to read a message
2. Decode fails
3. Consumer thread breaks and closes the broker's connection
4. Message is requeued
5. Consumer thread wake up and tries to read the same message again

I tried to follow the suggested approach presented in https://github.com/Bogdanp/dramatiq/issues/284, but I couldn't make it work. 

I think the encode side is safe because we can handle exceptions on the publisher side.

--

Note that the PR changes only applies to RabbitMQ broker. For Redis, I used the `JSONEncoder` as a fallback to access `redis_message_id` and rejects the message since it is not available after the exception occurs. But I don't know if it's the right approach.

```diff
diff --git a/dramatiq/brokers/redis.py b/dramatiq/brokers/redis.py
index 2aad9b2..9808319 100644
--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -27,7 +27,8 @@ import redis

 from ..broker import Broker, Consumer, MessageProxy
 from ..common import compute_backoff, current_millis, dq_name
-from ..errors import ConnectionClosed, QueueJoinTimeout
+from ..errors import ConnectionClosed, DecodeError, QueueJoinTimeout
+from ..encoder import JSONEncoder
 from ..logging import get_logger
 from ..message import Message

@@ -360,6 +361,11 @@ class _RedisConsumer(Consumer):
                         self.misses, backoff_ms = compute_backoff(self.misses, max_backoff=self.timeout)
                         time.sleep(backoff_ms / 1000)
                         return None
+                except DecodeError:
+                    message = Message(**JSONEncoder().decode(data))
+                    self.logger.warning("Failed to decode message", exc_info=True)
+                    self.nack(message)
+
         except redis.ConnectionError as e:
             raise ConnectionClosed(e) from None
```

<details>
<summary>Log from consumer thread</summary>
<pre>
worker.py                  275 CRITICAL Consumer encountered an unexpected error.
Traceback (most recent call last):
  File "/home/thomaz/dev/python/dramatiq/dramatiq/worker.py", line 259, in run
    for message in self.consumer:
  File "/home/thomaz/dev/python/dramatiq/dramatiq/brokers/rabbitmq.py", line 492, in __next__
    message = Message.decode(body)
  File "/home/thomaz/dev/python/dramatiq/dramatiq/message.py", line 96, in decode
    return cls(**global_encoder.decode(data))
  File "/home/thomaz/dev/python/dramatiq/tests/test_rabbitmq.py", line 471, in decode
    raise RuntimeError("xfail")
RuntimeError: xfail
[2021-01-18 13:24:37,328] [Thread-35] [dramatiq.worker.ConsumerThread(default)] [INFO] Restarting consumer in 3.00 seconds.
[2021-01-18 13:24:37,328] [Thread-35] [dramatiq.brokers.rabbitmq._RabbitmqConsumer] [ERROR] Failed to wait for all callbacks to complete.  This can happen when the RabbitMQ server is suddenly restarted.
Traceback (most recent call last):
  File "/home/thomaz/dev/python/dramatiq/dramatiq/brokers/rabbitmq.py", line 507, in close
    self.connection.add_callback_threadsafe(all_callbacks_handled.set)
  File "/home/thomaz.soares/.virtualenvs/dramatiq/lib/python3.7/site-packages/pika/adapters/blocking_connection.py", line 744, in add_callback_threadsafe
    'BlockingConnection.add_callback_threadsafe() called on '
pika.exceptions.ConnectionWrongStateError: BlockingConnection.add_callback_threadsafe() called on closed or closing connection.
rabbitmq.py                512 ERROR    Failed to wait for all callbacks to complete.  This can happen when the RabbitMQ server is suddenly restarted.
Traceback (most recent call last):
  File "/home/thomaz/dev/python/dramatiq/dramatiq/brokers/rabbitmq.py", line 507, in close
    self.connection.add_callback_threadsafe(all_callbacks_handled.set)
  File "/home/thomaz.soares/.virtualenvs/dramatiq/lib/python3.7/site-packages/pika/adapters/blocking_connection.py", line 744, in add_callback_threadsafe
    'BlockingConnection.add_callback_threadsafe() called on '
pika.exceptions.ConnectionWrongStateError: BlockingConnection.add_callback_threadsafe() called on closed or closing connection.
[2021-01-18 13:24:40,347] [Thread-35] [dramatiq.worker.ConsumerThread(default)] [CRITICAL] Consumer encountered an unexpected error.
Traceback (most recent call last):
  File "/home/thomaz/dev/python/dramatiq/dramatiq/worker.py", line 259, in run
    for message in self.consumer:
  File "/home/thomaz/dev/python/dramatiq/dramatiq/brokers/rabbitmq.py", line 492, in __next__
    message = Message.decode(body)
  File "/home/thomaz/dev/python/dramatiq/dramatiq/message.py", line 96, in decode
    return cls(**global_encoder.decode(data))
  File "/home/thomaz/dev/python/dramatiq/tests/test_rabbitmq.py", line 471, in decode
    raise RuntimeError("xfail")
RuntimeError: xfail
</pre>
</details>