### PR TITLE
Record when a message is recovered on a killed worker, and don't retry those tasks infinitely

### DIFF
--- a/dramatiq/brokers/redis/dispatch.lua
+++ b/dramatiq/brokers/redis/dispatch.lua
@@ -115,6 +115,21 @@ if do_maintenance == "1" then
         local dead_worker_queue_acks = dead_worker_acks .. "." .. queue_name
         local message_ids = redis.call("smembers", dead_worker_queue_acks)
         if next(message_ids) then
+            for i, message_id in ipairs(message_ids) do
+              local encoded_message = redis.call("hget", queue_messages, message_id)
+              if encoded_message ~= nil then
+                local message = cjson.decode(encoded_message)
+                -- Do we need to do this in case of multiple people running domaintenance?
+                -- redis.call("hdel", queue_messages, message_id)
+                if message['options']['revives'] ~= nil then
+                  message['options']['revives'] = message['options']['revives'] + 1
+                else
+                  message['options']['revives'] = 0
+                end
+                redis.call("hset", queue_messages, message_id, cjson.encode(message))
+              end
+            end
+
             for message_ids_batch in iter_chunks(message_ids) do
                 redis.call("rpush", queue_full_name, unpack(message_ids_batch))
             end

--- a/dramatiq/middleware/retries.py
+++ b/dramatiq/middleware/retries.py
@@ -80,6 +80,17 @@ class Retries(Middleware):
             "throws",
         }
 
+    def before_process_message(self, broker, message, *, result=None, exception=None):
+        max_revives = 1   # Or set by a config option
+
+        if "revives" in message.options and message.options["revives"] > max_revives:
+            self.logger.warning(
+                "This message exceeded its revive limit",
+                message.message_id
+            )
+            message.fail()
+            return
+
     def after_process_message(self, broker, message, *, result=None, exception=None):
         if exception is None:
             return

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -144,7 +144,7 @@ def test_redis_unacked_messages_can_be_requeued(redis_broker):
 
     # If I enqueue many messages
     for message_id in message_ids:
-        redis_broker.do_enqueue(queue_name, message_id, b"message-data")
+        redis_broker.do_enqueue(queue_name, message_id, b'{"options":{}}')
 
     # And then fetch them
     for _ in message_ids:


### PR DESCRIPTION
This is a POC for the feature of handling worker OOMKills.  I have started discussions  https://github.com/Bogdanp/dramatiq/issues/213 and https://www.reddit.com/r/dramatiq/comments/lgyhvl/why_is_do_maintenance_not_locked/? related to this, but I think this is a great solution, it works for me locally very well.  Obviously this PR isn't done, but please give me your thoughts!  Is this something we can consider adding once it's more fully written out?  Should I make it a separate middleware?