### PR TITLE
rabbitmq: ensure deleting `connection` and `channel` closes each

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,16 @@ Changed
 .. _#375: https://github.com/Bogdanp/dramatiq/pull/375
 .. _@thomazthz: https://github.com/thomazthz
 
+Fixed
+^^^^^
+
+* Deleting the connection off of a ``RabbitMQ`` broker now correctly
+  closes it and its associated channel (if any) before removing it
+  from the broker. (`#381`_, `#384`_)
+
+.. _#381: https://github.com/Bogdanp/dramatiq/issue/381
+.. _#381: https://github.com/Bogdanp/dramatiq/issue/384
+
 
 `1.10.0`_ -- 2020-12-21
 -----------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,12 +28,15 @@ Changed
 Fixed
 ^^^^^
 
+* A code path that could lead to an unbound variable error has now
+  been fixed.  (`#382`_)
 * Deleting the connection off of a ``RabbitMQ`` broker now correctly
   closes it and its associated channel (if any) before removing it
   from the broker. (`#381`_, `#384`_)
 
 .. _#381: https://github.com/Bogdanp/dramatiq/issue/381
-.. _#381: https://github.com/Bogdanp/dramatiq/issue/384
+.. _#382: https://github.com/Bogdanp/dramatiq/issue/382
+.. _#384: https://github.com/Bogdanp/dramatiq/issue/384
 
 
 `1.10.0`_ -- 2020-12-21

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -132,15 +132,16 @@ class RabbitmqBroker(Broker):
         del self.channel
         try:
             connection = self.state.connection
-            if connection.is_open:
-                try:
-                    connection.close()
-                except Exception:
-                    self.logger.exception("Encountered exception while closing Connection.")
-            del self.state.connection
-            self.connections.remove(connection)
         except AttributeError:
-            pass
+            return
+
+        del self.state.connection
+        self.connections.remove(connection)
+        if connection.is_open:
+            try:
+                connection.close()
+            except Exception:
+                self.logger.exception("Encountered exception while closing Connection.")
 
     @property
     def channel(self):
@@ -160,15 +161,16 @@ class RabbitmqBroker(Broker):
     def channel(self):
         try:
             channel = self.state.channel
-            if channel.is_open:
-                try:
-                    channel.close()
-                except Exception:
-                    self.logger.exception("Encountered exception while closing Channel.")
-            del self.state.channel
-            self.channels.remove(channel)
         except AttributeError:
-            pass
+            return
+
+        del self.state.channel
+        self.channels.remove(channel)
+        if channel.is_open:
+            try:
+                channel.close()
+            except Exception:
+                self.logger.exception("Encountered exception while closing Channel.")
 
     def close(self):
         """Close all open RabbitMQ connections.

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -466,6 +466,7 @@ class _WorkerThread(Thread):
         Parameters:
           message(MessageProxy)
         """
+        actor = None
         try:
             self.logger.debug("Received message %s with id %r.", message, message.message_id)
             self.broker.emit_before("process_message", message)
@@ -497,7 +498,7 @@ class _WorkerThread(Thread):
             # to pass exceptions into results.
             message.stuff_exception(e)
 
-            throws = message.options.get("throws") or actor.options.get("throws")
+            throws = message.options.get("throws") or (actor and actor.options.get("throws"))
             if isinstance(e, RateLimitExceeded):
                 self.logger.debug("Rate limit exceeded in message %s: %s.", message, e)
             elif throws and isinstance(e, throws):


### PR DESCRIPTION
Related to #381 and #321.