### PR TITLE
docs: add a missing comma in the sample code

### DIFF
--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -41,7 +41,7 @@ time an actor fails, even if the message is going to be retried.
 
    if __name__ == "__main__":
        identity.send_with_options(
-           args=(42,)
+           args=(42,),
            on_failure=print_error,
            on_success=print_result,
        )


### PR DESCRIPTION
Sorry for this very tiny PR.

Today I started learning dramatiq and I found an issue in the sample code in [the cookbook](https://dramatiq.io/cookbook.html).

```
if __name__ == "__main__":
    identity.send_with_options(
        args=(42,)
        on_failure=print_error,
        on_success=print_result,
    )
```
A comma is missing after `args=(42,)`. This PR fixes the issue.