### PR TITLE
Add injections field to Actor and Message

### DIFF
--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -49,6 +49,7 @@ class Actor:
         self.queue_name = queue_name
         self.priority = priority
         self.options = options
+        self.injections = {}
         self.broker.declare_actor(self)
 
     def message(self, *args, **kwargs):
@@ -142,7 +143,7 @@ class Actor:
         try:
             self.logger.debug("Received args=%r kwargs=%r.", args, kwargs)
             start = time.perf_counter()
-            return self.fn(*args, **kwargs)
+            return self.fn(*args, **self.injections, **kwargs)
         finally:
             delta = time.perf_counter() - start
             self.logger.debug("Completed after %.02fms.", delta * 1000)

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -74,11 +74,14 @@ class Message(namedtuple("Message", (
     """
 
     def __new__(cls, *, queue_name, actor_name, args, kwargs, options, message_id=None, message_timestamp=None):
-        return super().__new__(
+        self = super().__new__(
             cls, queue_name, actor_name, tuple(args), kwargs, options,
             message_id=message_id or generate_unique_id(),
             message_timestamp=message_timestamp or int(time.time() * 1000),
         )
+        # This is specifically not part of namedtuple so it's not part of _asdict() and such
+        self.injections = {}
+        return self
 
     def __or__(self, other) -> pipeline:
         """Combine this message into a pipeline with "other".

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -474,7 +474,7 @@ class _WorkerThread(Thread):
             res = None
             if not message.failed:
                 actor = self.broker.get_actor(message.actor_name)
-                res = actor(*message.args, **message.kwargs)
+                res = actor(*message.args, **message.injections, **message.kwargs)
                 if res is not None \
                    and message.options.get("pipe_target") is None \
                    and not has_results_middleware(self.broker):


### PR DESCRIPTION
This implements #389: provides a way for middleware to add keyword arguments that won't get serialized.

The way I set this up, caller arguments override message injections, which override actor injections.

This is deliberately meant to be a very minimal addition.