### PR TITLE
Add support for gevent to TimeLimit middleware

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,3 +48,4 @@ of those changes to CLEARTYPE SRL.
 | [@denhai](https://github.com/denhai)                  | Hayden Bartlett        |
 | [@rouge8](https://github.com/rouge8)                  | Andy Freeland          |
 | [@thomazthz](https://github.com/thomazthz)            | Thomaz Soares          |
+| [@finnlidbetter](https://github.com/finnlidbetter)    | Finn Lidbetter         |

--- a/dramatiq/middleware/threading.py
+++ b/dramatiq/middleware/threading.py
@@ -30,6 +30,15 @@ current_platform = platform.python_implementation()
 supported_platforms = {"CPython"}
 
 
+def is_gevent_active():
+    """Detect if gevent monkey patching is active."""
+    try:
+        from gevent import monkey
+    except ImportError:  # pragma: no cover
+        return False
+    return bool(monkey.saved)
+
+
 class Interrupt(BaseException):
     """Base class for exceptions used to asynchronously interrupt a
     thread's execution.  An actor may catch these exceptions in order

--- a/dramatiq/middleware/time_limit.py
+++ b/dramatiq/middleware/time_limit.py
@@ -22,13 +22,35 @@ from time import monotonic, sleep
 
 from ..logging import get_logger
 from .middleware import Middleware
-from .threading import Interrupt, current_platform, raise_thread_exception, supported_platforms
+from .threading import Interrupt, current_platform, is_gevent_active, raise_thread_exception, supported_platforms
 
 
 class TimeLimitExceeded(Interrupt):
     """Exception used to interrupt worker threads when actors exceed
     their time limits.
     """
+
+
+if is_gevent_active():
+    from gevent import Timeout
+
+    class TimeoutWithLogging(Timeout):
+        """Cooperative timeout class for gevent with logging on timeouts."""
+
+        def __init__(self, *args, thread_id=None, logger=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            if logger is None:
+                logger = get_logger(__name__, type(self))
+            self.logger = logger
+            self.thread_id = thread_id
+
+        def _on_expiration(self, prev_greenlet, ex):
+            self.logger.warning(
+                "Time limit exceeded. Raising exception in worker thread %r.", self.thread_id)
+            return super()._on_expiration(prev_greenlet, ex)
+    GeventTimeout = TimeoutWithLogging
+else:
+    GeventTimeout = None
 
 
 class TimeLimit(Middleware):
@@ -46,7 +68,8 @@ class TimeLimit(Middleware):
         run for. Use `float("inf")` to avoid setting a timeout for the
         actor.
       interval(int): The interval (in milliseconds) with which to
-        check for actors that have exceeded the limit.
+        check for actors that have exceeded the limit. This does not take
+        effect when using gevent because the timers are managed by gevent.
     """
 
     def __init__(self, *, time_limit=600000, interval=1000):
@@ -54,6 +77,7 @@ class TimeLimit(Middleware):
         self.time_limit = time_limit
         self.interval = interval / 1000
         self.deadlines = {}
+        self.gevent_timers = {}
 
     def _handle(self):
         current_time = monotonic()
@@ -78,8 +102,9 @@ class TimeLimit(Middleware):
 
     def after_process_boot(self, broker):
         if current_platform in supported_platforms:
-            thread = Thread(target=self._timer, daemon=True)
-            thread.start()
+            if not is_gevent_active():
+                thread = Thread(target=self._timer, daemon=True)
+                thread.start()
 
         else:  # pragma: no cover
             msg = "TimeLimit cannot kill threads on your current platform (%r)."
@@ -88,10 +113,30 @@ class TimeLimit(Middleware):
     def before_process_message(self, broker, message):
         actor = broker.get_actor(message.actor_name)
         limit = message.options.get("time_limit") or actor.options.get("time_limit", self.time_limit)
-        deadline = monotonic() + limit / 1000
-        self.deadlines[threading.get_ident()] = deadline
+        thread_id = threading.get_ident()
+        if is_gevent_active():
+            # Gevent timers use None to indicate no timeout.
+            gevent_timeout_seconds = None if limit == float("inf") else limit / 1000
+            timeout = GeventTimeout(
+                logger=self.logger, thread_id=thread_id,
+                seconds=gevent_timeout_seconds, exception=TimeLimitExceeded)
+            self.gevent_timers[thread_id] = timeout
+            timeout.start()
+        else:
+            deadline = monotonic() + limit / 1000
+            self.deadlines[thread_id] = deadline
 
     def after_process_message(self, broker, message, *, result=None, exception=None):
-        self.deadlines[threading.get_ident()] = None
+        thread_id = threading.get_ident()
+        if is_gevent_active():
+            if thread_id in self.gevent_timers and self.gevent_timers[thread_id] is not None:
+                self.gevent_timers[thread_id].close()
+                self.gevent_timers[thread_id] = None
+            else:  # pragma: no cover
+                self.logger.error(
+                    "No gevent timer found to close in thread %r for message_id '%s'.",
+                    thread_id, message.message_id)
+        else:
+            self.deadlines[thread_id] = None
 
     after_skip_message = after_process_message

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,10 @@ dependencies = [
 ]
 
 extra_dependencies = {
+    "gevent": [
+        "gevent>=1.1",
+    ],
+
     "memcached": [
         "pylibmc>=1.5,<2.0",
     ],

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,6 +6,7 @@ import pika
 import pytest
 
 from dramatiq import Worker
+from dramatiq.middleware.threading import is_gevent_active
 
 
 @contextmanager
@@ -26,6 +27,8 @@ skip_in_ci = pytest.mark.skipif(
 
 skip_on_windows = pytest.mark.skipif(platform.system() == "Windows", reason="test skipped on Windows")
 skip_on_pypy = pytest.mark.skipif(platform.python_implementation() == "PyPy", reason="Time limits are not supported under PyPy.")
+skip_with_gevent = pytest.mark.skipif(is_gevent_active(), reason="Behaviour with gevent is different.")
+skip_without_gevent = pytest.mark.skipif(not is_gevent_active(), reason="Behaviour without gevent is different.")
 
 RABBITMQ_USERNAME = os.getenv("RABBITMQ_USERNAME", "guest")
 RABBITMQ_PASSWORD = os.getenv("RABBITMQ_PASSWORD", "guest")

--- a/tests/middleware/test_shutdown.py
+++ b/tests/middleware/test_shutdown.py
@@ -84,6 +84,7 @@ def test_shutdown_notifications_options(stub_broker, actor_opt, message_opt, sho
     assert middleware.should_notify(do_work, message) == should_notify
 
 
+@pytest.mark.xfail(threading.is_gevent_active(), reason="Shutdown notification mechanism not supported with gevent.")
 @pytest.mark.skipif(not_supported, reason="Threading not supported on this platform.")
 def test_shutdown_notifications_are_received(stub_broker, stub_worker):
     # Given that I have a database
@@ -147,6 +148,7 @@ def test_shutdown_notifications_can_be_ignored(stub_broker, stub_worker):
     assert sum(successes) == 1
 
 
+@pytest.mark.xfail(threading.is_gevent_active(), reason="Shutdown notification mechanism not supported with gevent.")
 @pytest.mark.skipif(not_supported, reason="Threading not supported on this platform.")
 def test_shutdown_notifications_dont_notify_completed_threads(stub_broker, stub_worker):
     # Given that I have a database

--- a/tests/middleware/test_threading.py
+++ b/tests/middleware/test_threading.py
@@ -10,6 +10,7 @@ not_supported = threading.current_platform not in threading.supported_platforms
 
 
 @pytest.mark.skipif(not_supported, reason="Threading not supported on this platform.")
+@pytest.mark.skipif(threading.is_gevent_active(), reason="Thread exceptions not supported with gevent.")
 def test_raise_thread_exception():
     # Given that I have a database
     caught = []
@@ -36,6 +37,7 @@ def test_raise_thread_exception():
 
 
 @pytest.mark.skipif(not_supported, reason="Threading not supported on this platform.")
+@pytest.mark.skipif(threading.is_gevent_active(), reason="Thread exceptions not supported with gevent.")
 def test_raise_thread_exception_on_nonexistent_thread(caplog):
     # When an interrupt is raised on a nonexistent thread
     threading.raise_thread_exception(-1, threading.Interrupt)

--- a/tests/middleware/test_time_limit.py
+++ b/tests/middleware/test_time_limit.py
@@ -1,0 +1,273 @@
+import logging
+import time
+from threading import get_ident as get_thread_ident
+from unittest import mock
+
+import pytest
+from gevent.timeout import _FakeTimer
+from greenlet import getcurrent
+
+import dramatiq
+from dramatiq.brokers.stub import StubBroker
+from dramatiq.middleware import time_limit, threading
+
+from ..common import skip_with_gevent, skip_without_gevent
+
+
+not_supported = threading.current_platform not in threading.supported_platforms
+
+
+def test_time_limit_platform_not_supported(recwarn, monkeypatch):
+    # monkeypatch fake platform to test logging.
+    monkeypatch.setattr(time_limit, "current_platform", "not supported")
+
+    # Given a broker configured with time limits
+    broker = StubBroker(middleware=[time_limit.TimeLimit()])
+
+    # When the process boots
+    broker.emit_after("process_boot")
+
+    # A platform support warning is issued
+    assert len(recwarn) == 1
+    assert str(recwarn[0].message) == ("TimeLimit cannot kill threads "
+                                       "on your current platform ('not supported').")
+
+
+@skip_with_gevent
+@mock.patch("dramatiq.middleware.time_limit.raise_thread_exception")
+def test_time_limit_exceeded_worker_messages(raise_thread_exception, caplog):
+    # capture all messages
+    caplog.set_level(logging.NOTSET)
+
+    current_time = time.monotonic()
+
+    # Given a middleware with two "threads" that have exceeded their deadlines
+    # and one "thread" that has not
+    middleware = time_limit.TimeLimit()
+    middleware.deadlines = {
+        1: current_time - 2, 2: current_time - 1, 3: current_time + 50000}
+
+    # When the time limit handler is triggered
+    middleware._handle()
+
+    # TimeLimitExceeded interrupts are raised in two of the threads
+    raise_thread_exception.assert_has_calls([
+        mock.call(1, time_limit.TimeLimitExceeded),
+        mock.call(2, time_limit.TimeLimitExceeded),
+    ])
+
+    # And TimeLimitExceeded warnings are logged for those threads.
+    assert len(caplog.record_tuples) == 2
+    assert caplog.record_tuples == [
+        ("dramatiq.middleware.time_limit.TimeLimit", logging.WARNING, (
+            "Time limit exceeded. Raising exception in worker thread 1."
+        )),
+        ("dramatiq.middleware.time_limit.TimeLimit", logging.WARNING, (
+            "Time limit exceeded. Raising exception in worker thread 2."
+        )),
+    ]
+
+
+@skip_without_gevent
+@mock.patch("dramatiq.middleware.time_limit.Timeout._on_expiration")
+def test_time_limit_exceeded_gevent_worker_messages(on_expiration, caplog):
+    # capture all messages
+    caplog.set_level(logging.NOTSET)
+
+    # Given a time limit middleware instance and three gevent timers with
+    # two short time limits and one long time limit
+    middleware = time_limit.TimeLimit()
+    timer_1 = time_limit.GeventTimeout(
+        seconds=.01, thread_id=1, logger=middleware.logger,
+        exception=time_limit.TimeLimitExceeded)
+    timer_2 = time_limit.GeventTimeout(
+        seconds=.02, thread_id=2, logger=middleware.logger,
+        exception=time_limit.TimeLimitExceeded)
+    timer_3 = time_limit.GeventTimeout(
+        seconds=10, thread_id=3, logger=middleware.logger,
+        exception=time_limit.TimeLimitExceeded)
+
+    # When the timers are all started
+    timer_1.start()
+    timer_2.start()
+    timer_3.start()
+
+    # And enough time passes for two of the time limits to be exceeded
+    time.sleep(.1)
+
+    # I expect TimeLimitExceeded exceptions to be used in the on_expiration
+    # callbacks for those timers
+    current_greenlet = getcurrent()
+    assert on_expiration.assert_has_calls
+    on_expiration.assert_has_calls([
+        mock.call(current_greenlet, time_limit.TimeLimitExceeded),
+        mock.call(current_greenlet, time_limit.TimeLimitExceeded),
+    ])
+
+    # And I expect TimeLimitExceeded warnings to be logged for the expected
+    # threads.
+    assert len(caplog.record_tuples) == 2
+    assert caplog.record_tuples == [
+        ("dramatiq.middleware.time_limit.TimeLimit", logging.WARNING, (
+            "Time limit exceeded. Raising exception in worker thread 1."
+        )),
+        ("dramatiq.middleware.time_limit.TimeLimit", logging.WARNING, (
+            "Time limit exceeded. Raising exception in worker thread 2."
+        )),
+    ]
+    timer_1.close()
+    timer_2.close()
+    timer_3.close()
+
+
+@pytest.mark.skipif(not_supported, reason="Threading not supported on this platform.")
+def test_time_limits_are_handled(stub_broker, stub_worker):
+    # Given that I have a database
+    time_limits_exceeded, successes = [], []
+
+    # And an actor that handles time limit exceeded interrupts
+    @dramatiq.actor(time_limit=10, max_retries=0)
+    def do_work():
+        try:
+            for _ in range(20):
+                time.sleep(.1)
+        except time_limit.TimeLimitExceeded:
+            time_limits_exceeded.append(1)
+            raise
+        successes.append(1)
+
+    # If I send it a message
+    do_work.send()
+
+    # Then join on the queue
+    stub_broker.join(do_work.queue_name)
+    stub_worker.join()
+
+    # I expect the time limit to have been exceeded
+    assert sum(time_limits_exceeded) == 1
+    assert sum(successes) == 0
+
+
+@skip_with_gevent
+@pytest.mark.parametrize("message_opt, actor_opt, expected_deadline", [
+    (None, None, 600), (None, 2000, 2), (1000, None, 1), (1000, 2000, 1),
+    (2000, 1000, 2), (1200, None, 1.2), (None, 1200, 1.2),
+    (float("inf"), 2000, float("inf")), (None, float("inf"), float("inf")),
+])
+@mock.patch("dramatiq.middleware.time_limit.monotonic", return_value=0)
+def test_time_limits_are_tracked(_mock_monotonic, message_opt, actor_opt, expected_deadline):
+    # Given that I have a time limit middleware instance
+    middleware = time_limit.TimeLimit()
+
+    # And a mock actor and mock message with the specified options
+    actor_options = {} if actor_opt is None else {"time_limit": actor_opt}
+    message_options = {} if message_opt is None else {"time_limit": message_opt}
+    mock_actor = mock.Mock(options=actor_options)
+    mock_broker = mock.Mock(get_actor=lambda _actor_name: mock_actor)
+    mock_message = mock.Mock(options=message_options)
+
+    # When I trigger before_process_message for the middleware
+    middleware.before_process_message(mock_broker, mock_message)
+
+    # The middleware sets the expected deadline for the thread.
+    thread_id = get_thread_ident()
+    assert len(middleware.deadlines) == 1
+    assert middleware.deadlines[thread_id] == expected_deadline
+
+
+@skip_without_gevent
+@pytest.mark.parametrize("message_opt, actor_opt, expected_seconds", [
+    (None, None, 600), (None, 2000, 2), (1000, None, 1), (1000, 2000, 1),
+    (2000, 1000, 2), (1200, None, 1.2), (None, 1200, 1.2),
+    (float("inf"), 2000, None), (None, float("inf"), None),
+])
+def test_time_limits_are_tracked_with_gevent(message_opt, actor_opt, expected_seconds):
+    # Given that I have a time limit middleware instance
+    middleware = time_limit.TimeLimit()
+
+    # And a mock actor and mock message with the specified options
+    actor_options = {} if actor_opt is None else {"time_limit": actor_opt}
+    message_options = {} if message_opt is None else {"time_limit": message_opt}
+    mock_actor = mock.Mock(options=actor_options)
+    mock_broker = mock.Mock(get_actor=lambda _actor_name: mock_actor)
+    mock_message = mock.Mock(options=message_options)
+
+    # When I trigger before_process_message for the middleware
+    middleware.before_process_message(mock_broker, mock_message)
+
+    # I expect the middleware to have set gevent timeouts with the expected
+    # number of seconds
+    thread_id = get_thread_ident()
+    assert len(middleware.gevent_timers) == 1
+    assert middleware.gevent_timers[thread_id].seconds == expected_seconds
+    # And the gevent timer is faked if the expected_seconds is None.
+    if expected_seconds is None:
+        assert isinstance(middleware.gevent_timers[thread_id].timer, type(_FakeTimer))
+
+    middleware.gevent_timers[thread_id].close()
+
+
+@skip_with_gevent
+def test_time_limits_are_cleaned_up_after_processing():
+    # Given that I have a time limit middleware instance
+    middleware = time_limit.TimeLimit()
+
+    # With a deadline set for a thread
+    thread_id = get_thread_ident()
+    middleware.deadlines[thread_id] = 1000
+
+    # After a message is processed by the thread, the deadline for the thread
+    # is set to None.
+    middleware.after_process_message(mock.Mock(), mock.Mock())
+    assert middleware.deadlines[thread_id] is None
+
+
+@skip_with_gevent
+def test_time_limits_are_cleaned_up_after_skipping():
+    # Given that I have a time limit middleware instance
+    middleware = time_limit.TimeLimit()
+
+    # With a deadline set for a thread
+    thread_id = get_thread_ident()
+    middleware.deadlines[thread_id] = 1000
+
+    # After a message is skipped by the thread, the deadline for the thread
+    # is set to None.
+    middleware.after_skip_message(mock.Mock(), mock.Mock())
+    assert middleware.deadlines[thread_id] is None
+
+
+@skip_without_gevent
+def test_time_limits_are_cleaned_up_after_processing_gevent():
+    # Given that I have a time limit middleware instance
+    middleware = time_limit.TimeLimit()
+
+    # With a mock gevent timeout set for a thread
+    thread_id = get_thread_ident()
+    mock_close = mock.Mock()
+    mock_timeout = mock.Mock(close=mock_close)
+    middleware.gevent_timers[thread_id] = mock_timeout
+
+    # After a message is processed by the thread, the timeout for the thread
+    # is closed and set to None.
+    middleware.after_process_message(mock.Mock(), mock.Mock())
+    assert mock_close.called
+    assert middleware.gevent_timers[thread_id] is None
+
+
+@skip_without_gevent
+def test_time_limits_are_cleaned_up_after_skipping_gevent():
+    # Given that I have a time limit middleware instance
+    middleware = time_limit.TimeLimit()
+
+    # With a mock gevent timeout set for a thread
+    thread_id = get_thread_ident()
+    mock_close = mock.Mock()
+    mock_timeout = mock.Mock(close=mock_close)
+    middleware.gevent_timers[thread_id] = mock_timeout
+
+    # After a message is processed by the thread, the timeout for the thread
+    # is closed and set to None.
+    middleware.after_skip_message(mock.Mock(), mock.Mock())
+    assert mock_close.called
+    assert middleware.gevent_timers[thread_id] is None

--- a/tests/pytest-gevent.py
+++ b/tests/pytest-gevent.py
@@ -1,0 +1,15 @@
+#!python
+try:
+    from gevent import monkey; monkey.patch_all()  # noqa
+except ImportError:
+    import sys
+
+    sys.stderr.write("error: gevent is missing. Run `pip install gevent`.")
+    sys.exit(1)
+
+import sys
+
+import pytest
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(args=sys.argv[1:]))

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ extras=
   dev
 commands=
   py.test --benchmark-skip {posargs}
+  python {toxinidir}/tests/pytest-gevent.py --benchmark-skip --cov-append {posargs}
 passenv=
   TRAVIS
 


### PR DESCRIPTION
Fixes Issue #403

- Adds function to check if gevent monkey patching is in use
- Adds gevent to list of extra dependencies
- Makes Time Limit middleware use gevent Timeout objects if gevent is
  being used
- Adds testing for the time limit middleware (for gevent and non-gevent)
- Adds testing script for running pytest with gevent monkey-patching
- Adds gevent pytest command to tox with --cov-append.
- Identifies existing tests that fail with gevent (shutdown notification
  middleware). I suggest that fixing this other issue should be out of
  scope for this PR.

Note that this *doubles* the length of time that it takes tests to run
since tests are run once with gevent and once without. This approach to
testing of running *everything* twice should be considered carefully
before accepting. 
I am open to revising this to only running certain marked tests with gevent,
but running the whole test suite with gevent does not seem inappropriate
to me and it is certainly safer for catching regressions and identifying future 
incompatibilities.