### PR TITLE
Add max_age as a message option

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,3 +48,4 @@ of those changes to CLEARTYPE SRL.
 | [@denhai](https://github.com/denhai)                  | Hayden Bartlett        |
 | [@rouge8](https://github.com/rouge8)                  | Andy Freeland          |
 | [@thomazthz](https://github.com/thomazthz)            | Thomaz Soares          |
+| [@FinnLidbetter](https://github.com/FinnLidbetter)    | Finn Lidbetter         |

--- a/dramatiq/middleware/age_limit.py
+++ b/dramatiq/middleware/age_limit.py
@@ -40,7 +40,7 @@ class AgeLimit(Middleware):
 
     def before_process_message(self, broker, message):
         actor = broker.get_actor(message.actor_name)
-        max_age = actor.options.get("max_age", self.max_age)
+        max_age = message.options.get("max_age") or actor.options.get("max_age", self.max_age)
         if not max_age:
             return
 


### PR DESCRIPTION
Addresses https://github.com/Bogdanp/dramatiq/issues/416

Note that the implementation is consistent with the timelimit middleware
but there is an edge case where setting a max_age of 0 will behave the
same as None, since 0 is falsey.
But this does not seem important as I cannot imagine a use-case for using
a max_age of 0. Could be fixed with explicit None checks.