### PR TITLE
Typos in cookbook codes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,3 +49,4 @@ of those changes to CLEARTYPE SRL.
 | [@rouge8](https://github.com/rouge8)                  | Andy Freeland          |
 | [@thomazthz](https://github.com/thomazthz)            | Thomaz Soares          |
 | [@FinnLidbetter](https://github.com/FinnLidbetter)    | Finn Lidbetter         |
+| [@kurrbanov](https://github.com/kurrbanov)            | Radif Kurbanov         |

--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -437,7 +437,9 @@ Aborting Messages
 
 The `dramatiq-abort`_ package provides a middleware that can be used
 to abort running actors by message id.  Here's how you might set it
-up::
+up:
+
+.. code-block:: python
 
   import dramatiq
   import dramatiq_abort.backends

--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -31,7 +31,8 @@ time an actor fails, even if the message is going to be retried.
    @dramatiq.actor
    def print_result(message_data, result):
        print(f"The result of message {message_data['message_id']} was {result}.")
-
+   
+   
    @dramatiq.actor
    def print_error(message_data, exception_data):
        print(f"Message {message_data['message_id']} failed:")
@@ -446,6 +447,7 @@ up::
       backend=dramatiq_abort.backends.RedisBackend()
   )
   dramatiq.get_broker().add_middleware(abortable)
+
 
   @dramatiq.actor
   def a_long_running_task():

--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -403,7 +403,6 @@ APScheduler_ is the recommended scheduler to use with Dramatiq:
 .. code-block:: python
 
    import dramatiq
-   import sys
 
    from apscheduler.schedulers.blocking import BlockingScheduler
    from apscheduler.triggers.cron import CronTrigger


### PR DESCRIPTION
- Removed unused import sys
- Added the blank lines before functions
- Added the Python-style code-block  to aborting code example