### PR TITLE
Fix AsyncExc thread_id ctype for python >= 3.7

### DIFF
--- a/dramatiq/middleware/threading.py
+++ b/dramatiq/middleware/threading.py
@@ -27,6 +27,8 @@ __all__ = ["Interrupt", "raise_thread_exception"]
 logger = get_logger(__name__)
 
 current_platform = platform.python_implementation()
+python_version = platform.python_version_tuple()
+thread_id_ctype = ctypes.c_long if python_version < ("3", "7") else ctypes.c_ulong
 supported_platforms = {"CPython"}
 
 
@@ -61,7 +63,7 @@ def raise_thread_exception(thread_id, exception):
 
 def _raise_thread_exception_cpython(thread_id, exception):
     exctype = (exception if inspect.isclass(exception) else type(exception)).__name__
-    thread_id = ctypes.c_long(thread_id)
+    thread_id = thread_id_ctype(thread_id)
     exception = ctypes.py_object(exception)
     count = ctypes.pythonapi.PyThreadState_SetAsyncExc(thread_id, exception)
     if count == 0:

--- a/tests/middleware/test_threading.py
+++ b/tests/middleware/test_threading.py
@@ -40,11 +40,11 @@ def test_raise_thread_exception_on_nonexistent_thread(caplog):
     # When an interrupt is raised on a nonexistent thread
     threading.raise_thread_exception(-1, threading.Interrupt)
 
+    processed_thread_id = -1 if threading.python_version < ("3", "7") else 2 ** 64 - 1
+    expected_message = "Failed to set exception (Interrupt) in thread %d." % processed_thread_id
     # I expect a 'failed to set exception' critical message to be logged
     assert caplog.record_tuples == [
-        ("dramatiq.middleware.threading", logging.CRITICAL, (
-            "Failed to set exception (Interrupt) in thread -1."
-        )),
+        ("dramatiq.middleware.threading", logging.CRITICAL, expected_message),
     ]
 
 

--- a/tests/middleware/test_threading.py
+++ b/tests/middleware/test_threading.py
@@ -38,11 +38,11 @@ def test_raise_thread_exception():
 @pytest.mark.skipif(not_supported, reason="Threading not supported on this platform.")
 def test_raise_thread_exception_on_nonexistent_thread(caplog):
     # When an interrupt is raised on a nonexistent thread
-    threading.raise_thread_exception(-1, threading.Interrupt)
+    thread_id = 2 ** 31 - 1
+    threading.raise_thread_exception(thread_id, threading.Interrupt)
 
-    processed_thread_id = -1 if threading.python_version < ("3", "7") else 2 ** 64 - 1
-    expected_message = "Failed to set exception (Interrupt) in thread %d." % processed_thread_id
     # I expect a 'failed to set exception' critical message to be logged
+    expected_message = "Failed to set exception (Interrupt) in thread %d." % thread_id
     assert caplog.record_tuples == [
         ("dramatiq.middleware.threading", logging.CRITICAL, expected_message),
     ]


### PR DESCRIPTION
Fixes issue #419