### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-18.04"]
-        python: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         concurrency: ["cpython", "gevent"]
 
     runs-on: ${{ matrix.os }}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 `Unreleased`_
 -------------
 
+Removed
+^^^^^^^
+
+* Dropped Python 3.5 support as it reached end-of-life
+
+
 `1.12.0`_ -- 2021-10-23
 -----------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ Here's what it looks like:
   count_words.send("http://example.com")
 
 **Dramatiq** is :doc:`licensed<license>` under the LGPL and it
-officially supports Python 3.5 and later.
+officially supports Python 3.6 and later.
 
 
 Get It Now

--- a/setup.py
+++ b/setup.py
@@ -111,12 +111,11 @@ setup(
     ],
     include_package_data=True,
     install_requires=dependencies,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     extras_require=extra_dependencies,
     entry_points={"console_scripts": ["dramatiq = dramatiq.__main__:main"]},
     scripts=["bin/dramatiq-gevent"],
     classifiers=[
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-  py{35,36,37,38,39}-cpython
-  py{35,36,37,38,39}-cpython-gevent
+  py{36,37,38,39}-cpython
+  py{36,37,38,39}-cpython-gevent
   docs
   lint
 


### PR DESCRIPTION
Greetings @Bogdanp!

I am opening this PR, as Python 3.5 reached end-of-life (https://devguide.python.org/devcycle/#end-of-life-branches).

Do you think it make sense to you or are there any good reasons to keep supporting this version?

Best,
Rust
