### PR TITLE
Stuff SkipMessage and fail skipped messages

### DIFF
--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -391,7 +391,17 @@ stored yet or if it has already expired (results expire after 10
 minutes by default).  When the ``block`` parameter is ``True``,
 |ResultTimeout| is raised instead.
 
-Results may expiry, otherwise the result backend might
+If processing a message fails (after exceeding allowed retries),
+then getting a result raises |ResultFailure| and information about
+the exception associated with the failure is stored on the
+|ResultFailure| exception object. If a message is skipped, via
+raising a |SkipMessage| exception, then if the message was failed
+with ``message.fail()`` (as in the |AgeLimit| middleware), then
+getting a result raises |ResultFailure|.
+Otherwise, if the message was skipped but not failed, then ``None``
+will be stored as the result.
+
+Results may expire, otherwise the result backend might
 eventually run out of space. 
 The timeout for the results expiration is set on `result_ttl`
 argument of |Results|, given in milliseconds. The default

--- a/docs/source/global.rst
+++ b/docs/source/global.rst
@@ -1,7 +1,7 @@
 .. References
 
-.. |AgeLimit| replace:: :class:`Callbacks<dramatiq.middleware.AgeLimit>`
-.. |Barriers| replace:: :class:`Barrires<dramatiq.rate_limits.Barrier>`
+.. |AgeLimit| replace:: :class:`AgeLimit<dramatiq.middleware.AgeLimit>`
+.. |Barriers| replace:: :class:`Barriers<dramatiq.rate_limits.Barrier>`
 .. |Brokers| replace:: :class:`Brokers<dramatiq.Broker>`
 .. |Broker| replace:: :class:`Broker<dramatiq.Broker>`
 .. |Callbacks| replace:: :class:`Callbacks<dramatiq.middleware.Callbacks>`
@@ -24,6 +24,7 @@
 .. |RedisResBackend| replace:: :class:`Redis<dramatiq.results.backends.RedisBackend>`
 .. |ResultBackends| replace:: :class:`ResultBackends<dramatiq.results.ResultBackend>`
 .. |ResultBackend| replace:: :class:`ResultBackend<dramatiq.results.ResultBackend>`
+.. |ResultFailure| replace:: :class:`ResultFailure<dramatiq.results.ResultFailure>`
 .. |ResultMissing| replace:: :class:`ResultMissing<dramatiq.results.ResultMissing>`
 .. |ResultTimeout| replace:: :class:`ResultTimeout<dramatiq.results.ResultTimeout>`
 .. |Results| replace:: :class:`Results<dramatiq.results.Results>`

--- a/dramatiq/middleware/age_limit.py
+++ b/dramatiq/middleware/age_limit.py
@@ -46,4 +46,5 @@ class AgeLimit(Middleware):
 
         if current_millis() - message.message_timestamp >= max_age:
             self.logger.warning("Message %r has exceeded its age limit.", message.message_id)
+            message.fail()
             raise SkipMessage("Message age limit exceeded")

--- a/dramatiq/middleware/age_limit.py
+++ b/dramatiq/middleware/age_limit.py
@@ -17,7 +17,7 @@
 
 from ..common import current_millis
 from ..logging import get_logger
-from .middleware import Middleware
+from .middleware import Middleware, SkipMessage
 
 
 class AgeLimit(Middleware):
@@ -46,5 +46,4 @@ class AgeLimit(Middleware):
 
         if current_millis() - message.message_timestamp >= max_age:
             self.logger.warning("Message %r has exceeded its age limit.", message.message_id)
-            message.fail()
-            return
+            raise SkipMessage("Message age limit exceeded")

--- a/dramatiq/results/middleware.py
+++ b/dramatiq/results/middleware.py
@@ -103,9 +103,12 @@ class Results(Middleware):
             )
 
     def after_skip_message(self, broker, message):
+        """If the message was skipped but not failed, then store None.
+        Let after_nack handle the case where the message was skipped and failed.
+        """
         store_results, result_ttl = self._lookup_options(broker, message)
-        if store_results and message._exception is not None:
-            self.backend.store_exception(message, message._exception, result_ttl)
+        if store_results and not message.failed:
+            self.backend.store_result(message, None, result_ttl)
 
     def after_nack(self, broker, message):
         store_results, result_ttl = self._lookup_options(broker, message)

--- a/dramatiq/results/middleware.py
+++ b/dramatiq/results/middleware.py
@@ -102,6 +102,11 @@ class Results(Middleware):
                 "the value has been discarded." % message.actor_name
             )
 
+    def after_skip_message(self, broker, message):
+        store_results, result_ttl = self._lookup_options(broker, message)
+        if store_results and message._exception is not None:
+            self.backend.store_exception(message, message._exception, result_ttl)
+
     def after_nack(self, broker, message):
         store_results, result_ttl = self._lookup_options(broker, message)
         if store_results and message.failed:

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -496,7 +496,8 @@ class _WorkerThread(Thread):
             self.broker.emit_after("process_message", message, result=res)
 
         except SkipMessage as e:
-            message.stuff_exception(e)
+            if message.failed:
+                message.stuff_exception(e)
             self.logger.warning("Message %s was skipped.", message)
             self.broker.emit_after("skip_message", message)
 

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -466,7 +466,10 @@ class _WorkerThread(Thread):
 
     def process_message(self, message):
         """Process a message pulled off of the work queue then push it
-        back to its associated consumer for post processing.
+        back to its associated consumer for post processing. Stuff any SkipMessage
+        exception or BaseException into the message [proxy] so that it may be used
+        by the stub broker to provide a nicer testing experience. Also used by the
+        results middleware to pass exceptions into results.
 
         Parameters:
           message(MessageProxy)
@@ -492,15 +495,13 @@ class _WorkerThread(Thread):
 
             self.broker.emit_after("process_message", message, result=res)
 
-        except SkipMessage:
+        except SkipMessage as e:
+            message.fail()
+            message.stuff_exception(e)
             self.logger.warning("Message %s was skipped.", message)
             self.broker.emit_after("skip_message", message)
 
         except BaseException as e:
-            # Stuff the exception into the message [proxy] so that it
-            # may be used by the stub broker to provide a nicer
-            # testing experience.  Also used by the results middleware
-            # to pass exceptions into results.
             message.stuff_exception(e)
 
             throws = message.options.get("throws") or (actor and actor.options.get("throws"))

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -496,7 +496,6 @@ class _WorkerThread(Thread):
             self.broker.emit_after("process_message", message, result=res)
 
         except SkipMessage as e:
-            message.fail()
             message.stuff_exception(e)
             self.logger.warning("Message %s was skipped.", message)
             self.broker.emit_after("skip_message", message)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -351,7 +351,7 @@ def test_custom_skipped_messages_store_consistent_exceptions(stub_broker, stub_w
     # And a broker with the results middleware
     stub_broker.add_middleware(Results(backend=result_backend))
 
-    # And a custom middleware that skips messages
+    # And a custom middleware that skips messages but does not fail messages
     class SkipMiddleware(Middleware):
         def before_process_message(self, broker, message):
             raise SkipMessage("Custom skip")

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -346,7 +346,7 @@ def test_age_limit_skipped_messages_store_consistent_exceptions(stub_broker, stu
     assert exc_2.value.orig_exc_msg == exc_1.value.orig_exc_msg
 
 
-def test_custom_skipped_messages_store_consistent_exceptions(stub_broker, stub_worker, result_backend):
+def test_custom_skipped_messages_with_no_fail_stores_none(stub_broker, stub_worker, result_backend):
     # Given a result backend
     # And a broker with the results middleware
     stub_broker.add_middleware(Results(backend=result_backend))
@@ -366,20 +366,11 @@ def test_custom_skipped_messages_store_consistent_exceptions(stub_broker, stub_w
     sent_message = do_work.send()
 
     # And wait for a result
-    # Then the result should be an exception
-    with pytest.raises(ResultFailure) as exc_1:
-        result_backend.get_result(sent_message, block=True)
-
-    assert str(exc_1.value) == "actor raised SkipMessage: Custom skip"
-    assert exc_1.value.orig_exc_type == "SkipMessage"
-    assert exc_1.value.orig_exc_msg == "Custom skip"
+    # Then the result should be None.
+    assert result_backend.get_result(sent_message, block=True) is None
 
     # If I sleep and get the result again
     time.sleep(0.2)
 
-    # Then the result should still be the same exception
-    with pytest.raises(ResultFailure) as exc_2:
-        result_backend.get_result(sent_message)
-    assert str(exc_2.value) == str(exc_1.value)
-    assert exc_2.value.orig_exc_type == exc_1.value.orig_exc_type
-    assert exc_2.value.orig_exc_msg == exc_1.value.orig_exc_msg
+    # Then the result should still be None.
+    assert result_backend.get_result(sent_message) is None


### PR DESCRIPTION
Fixes #440

Stuff SkipMessage exceptions into the message proxy to ensure that
the result is consistent when used in conjunction with the Results
middleware.
Additionally, move the message.fail() call into the SkipMessage
handling to ensure that skipped messages are nack'd rather than
ack'd.

Note that if failing the message is left to the middleware,
then unintentionally omitting message.fail() can lead to no result
ever being stored by the results middleware for the message.
If it should be left to the middleware to decide to fail the skipped
message then it would be more sensible to have fail as the default.
This could be achieved by making the SkipMessage exception take an
optional "fail_message" parameter that defaults to True, and have
the message conditionally fail() inside the worker SkipMessage
exception handling. Custom middleware could then raise SkipMessage
with fail_message=False to override this behaviour and lead to the
message being skipped and ack'd rather than skipped and nack'd.