### PR TITLE
Protect workers from early main process SIGHUP

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,11 @@
+import os
+import signal
+import time
 from subprocess import PIPE, STDOUT
+
+import dramatiq
+from dramatiq.brokers.redis import RedisBroker
+from dramatiq.common import current_millis
 
 from .common import skip_on_windows
 
@@ -7,6 +14,16 @@ fakebroker = object()
 
 class BrokerHolder:
     fakebroker = object()
+
+
+broker = RedisBroker()
+loaded_at = current_millis()
+
+
+@dramatiq.actor(broker=broker)
+def write_loaded_at(filename):
+    with open(filename, "w") as f:
+        f.write(str(loaded_at))
 
 
 @skip_on_windows
@@ -49,3 +66,40 @@ def test_cli_fails_to_start_given_an_invalid_nested_broker_instance(start_cli):
 
     # And the output should contain an error
     assert b"'tests.test_cli:BrokerHolder.fakebroker' is not a Broker." in proc.stdout.read()
+
+
+@skip_on_windows
+def test_cli_can_be_reloaded_on_sighup(start_cli):
+    # Given that I have a shared file the processes can use to communicate with
+    filename = "/tmp/dramatiq-cli-loaded-at"
+
+    # When I start my workers
+    proc = start_cli("tests.test_cli:broker", extra_args=[
+        "--processes", "1",
+        "--threads", "1",
+    ])
+
+    # And enqueue a task to write the loaded timestamp
+    write_loaded_at.send(filename)
+    broker.join(write_loaded_at.queue_name)
+
+    # Then I expect a timestamp to have been written to the file
+    with open(filename, "r") as f:
+        timestamp_1 = int(f.read())
+
+    # When I send a SIGHUP signal
+    os.kill(proc.pid, signal.SIGHUP)
+
+    # And wait for the workers to reload
+    time.sleep(5)
+
+    # And write another timestamp
+    write_loaded_at.send(filename)
+    broker.join(write_loaded_at.queue_name)
+
+    # Then I expect another timestamp to have been written to the file
+    with open(filename, "r") as f:
+        timestamp_2 = int(f.read())
+
+    # And the second time to be at least a second apart from the first
+    assert timestamp_2 - timestamp_1 >= 1000


### PR DESCRIPTION
Fixes #441

Note that the added testcase does not cover the issue described
in #441. The added test is a regression test only.
I am struggling to get a reliable test working that consistently
fails on master. The validation for the bugfix for #441 is manual
only.
Let me know if you would like to block merging this until an
automated test is added.