### PR TITLE
Remove (dict) from **kwargs types

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,3 +51,4 @@ of those changes to CLEARTYPE SRL.
 | [@FinnLidbetter](https://github.com/FinnLidbetter)    | Finn Lidbetter         |
 | [@giuppep](https://github.com/giuppep)                | Giuseppe Papallo       |
 | [@ethervoid](https://github.com/ethervoid)            | Mario de Frutos        |
+| [@pcrockett](https://github.com/pcrockett)            | Phil Crockett          |

--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -58,7 +58,7 @@ class Actor:
 
         Parameters:
           *args(tuple): Positional arguments to send to the actor.
-          **kwargs(dict): Keyword arguments to send to the actor.
+          **kwargs: Keyword arguments to send to the actor.
 
         Examples:
           >>> (add.message(1, 2) | add.message(3))
@@ -77,7 +77,7 @@ class Actor:
         Parameters:
           args(tuple): Positional arguments that are passed to the actor.
           kwargs(dict): Keyword arguments that are passed to the actor.
-          **options(dict): Arbitrary options that are passed to the
+          **options: Arbitrary options that are passed to the
             broker and any registered middleware.
 
         Returns:
@@ -103,7 +103,7 @@ class Actor:
 
         Parameters:
           *args(tuple): Positional arguments to send to the actor.
-          **kwargs(dict): Keyword arguments to send to the actor.
+          **kwargs: Keyword arguments to send to the actor.
 
         Returns:
           Message: The enqueued message.
@@ -120,7 +120,7 @@ class Actor:
           kwargs(dict): Keyword arguments that are passed to the actor.
           delay(int): The minimum amount of time, in milliseconds, the
             message should be delayed by.
-          **options(dict): Arbitrary options that are passed to the
+          **options: Arbitrary options that are passed to the
             broker and any registered middleware.
 
         Returns:
@@ -191,7 +191,7 @@ def actor(fn=None, *, actor_class=Actor, actor_name=None, queue_name="default", 
         priority than the other then it will be processed first.
         Lower numbers represent higher priorities.
       broker(Broker): The broker to use with this actor.
-      **options(dict): Arbitrary options that vary with the set of
+      **options: Arbitrary options that vary with the set of
         middleware that you use.  See ``get_broker().actor_options``.
 
     Returns:

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -79,7 +79,7 @@ class RabbitmqBroker(Broker):
         support queue-global priority queueing.
       parameters(list[dict]): A sequence of (pika) connection parameters
         to determine which Rabbit server(s) to connect to.
-      **kwargs(dict): The (pika) connection parameters to use to
+      **kwargs: The (pika) connection parameters to use to
         determine which Rabbit server to connect to.
 
     .. _ConnectionParameters: https://pika.readthedocs.io/en/0.12.0/modules/parameters.html

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -82,7 +82,7 @@ class RedisBroker(Broker):
       requeue_deadline(int): Deprecated.  Does nothing.
       requeue_interval(int): Deprecated.  Does nothing.
       client(redis.StrictRedis): A redis client to use.
-      **parameters(dict): Connection parameters are passed directly
+      **parameters: Connection parameters are passed directly
         to :class:`redis.Redis`.
 
     .. _Redis: http://redis-py.readthedocs.io/en/latest/#redis.Redis

--- a/dramatiq/rate_limits/backends/memcached.py
+++ b/dramatiq/rate_limits/backends/memcached.py
@@ -32,7 +32,7 @@ class MemcachedBackend(RateLimiterBackend):
       pool(ClientPool): An optional pylibmc client pool to use.  If
         this is passed, all other connection params are ignored.
       pool_size(int): The size of the connection pool to use.
-      **parameters(dict): Connection parameters are passed directly
+      **parameters: Connection parameters are passed directly
         to :class:`pylibmc.Client`.
 
     .. _memcached: https://memcached.org

--- a/dramatiq/rate_limits/backends/redis.py
+++ b/dramatiq/rate_limits/backends/redis.py
@@ -28,7 +28,7 @@ class RedisBackend(RateLimiterBackend):
         then all other parameters are ignored.
       url(str): An optional connection URL.  If both a URL and
         connection parameters are provided, the URL is used.
-      **parameters(dict): Connection parameters are passed directly
+      **parameters: Connection parameters are passed directly
         to :class:`redis.Redis`.
 
     .. _redis: https://redis.io

--- a/dramatiq/results/backends/memcached.py
+++ b/dramatiq/results/backends/memcached.py
@@ -31,7 +31,7 @@ class MemcachedBackend(ResultBackend):
       pool(ClientPool): An optional pylibmc client pool to use.  If
         this is passed, all other connection params are ignored.
       pool_size(int): The size of the connection pool to use.
-      **parameters(dict): Connection parameters are passed directly
+      **parameters: Connection parameters are passed directly
         to :class:`pylibmc.Client`.
 
     .. _memcached: https://memcached.org

--- a/dramatiq/results/backends/redis.py
+++ b/dramatiq/results/backends/redis.py
@@ -32,7 +32,7 @@ class RedisBackend(ResultBackend):
         then all other parameters are ignored.
       url(str): An optional connection URL.  If both a URL and
         connection parameters are provided, the URL is used.
-      **parameters(dict): Connection parameters are passed directly
+      **parameters: Connection parameters are passed directly
         to :class:`redis.Redis`.
 
     .. _redis: https://redis.io


### PR DESCRIPTION
Resolves #377 

According to [PEP 484](https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values), when writing types for `**kwargs` parameters, we're supposed to specify the type for the individual parameters. So when we say that `**options` is a `dict`, we're telling type checkers that _every parameter you pass as an option_ should be a `dict`.

If my understanding is correct, the types of these parameters could really be anything, so I just removed the type annotation entirely.

This cleans up a lot of big ugly warnings in PyCharm at least.