### PR TITLE
Allow using Redis 4.x. as a dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extra_dependencies = {
     ],
 
     "redis": [
-        "redis>=2.0,<4.0",
+        "redis>=2.0,<5.0",
     ],
 
     "watch": [


### PR DESCRIPTION
redis-py recently released version 4.0 which adds support for a few new APIs (in my case, I'm hoping to use some of the new Redis streams commands that are not available on 3.x). This change allows using Dramatiq with Redis 4.x.

I've tested this locally and with the CI workflow and things seem to work fine.

Looking through the list of [breaking changes](https://github.com/redis/redis-py/releases/tag/v4.0.0b1) there doesn't seem to be anything that directly impacts Dramatiq. The only thing tangentially related is [some changes](https://github.com/redis/redis-py/issues/589) to how URL encoded parameters in Redis URLs are handled.