### PR TITLE
feat(rabbitmq): rely on per-message ttl for delayed tasks

### DIFF
--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -185,6 +185,10 @@ class Worker:
                 return
 
     def _add_consumer(self, queue_name, *, delay=False):
+        if delay:
+            # Not creating the delayed queue, rely on message-ttl
+            return
+
         if queue_name in self.consumers:
             self.logger.debug("A consumer for queue %r is already running.", queue_name)
             return
@@ -273,7 +277,7 @@ class _ConsumerThread(Thread):
                         break
 
             except ConnectionError as e:
-                self.logger.critical("Consumer encountered a connection error: %s", e)
+                self.logger.critical("Consumer encountered a connection error: %s", e, exc_info=True)
                 self.delay_queue = PriorityQueue()
 
             except Exception:


### PR DESCRIPTION
### Proof-of-concept. 

Rabbitmq 3.8.25 (at AWS, using Amazon MQ RabbitMQ broker) has a default, not configurable, `consumer_timeout` of 30 minutes. Handling of delayed messages in Dramatiq requires the worker to prefetch messages and queue these internally. If a message is queued beyond the consumer timeout deadline, the connection raises an exception and is closed. This is causing problems when the worker is also processing tasks at the same time, when the task is finished, a new connection is available where the message tag is unknown. Also causing tasks to be redelivered, causing tasks to be executed twice.

### Solution
The proposed solution relies on a per-message ttl, where dramatiq doesnt need a separate worker to prefetch and queue delayed tasks internally.
