### PR TITLE
Adds closed attribute to StreamablePipe

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,3 +52,4 @@ of those changes to CLEARTYPE SRL.
 | [@giuppep](https://github.com/giuppep)                | Giuseppe Papallo       |
 | [@ethervoid](https://github.com/ethervoid)            | Mario de Frutos        |
 | [@pcrockett](https://github.com/pcrockett)            | Phil Crockett          |
+| [@pcrockett](https://github.com/nathanielobrown)      | Nathaniel Brown        |

--- a/dramatiq/compat.py
+++ b/dramatiq/compat.py
@@ -54,6 +54,10 @@ class StreamablePipe:
     def write(self, s):
         self.pipe.send_bytes(s.encode(self.encoding, errors="replace"))
 
+    @property
+    def closed(self):
+        return self.pipe.closed
+
 
 def file_or_stderr(filename, *, mode="a", encoding="utf-8"):
     """Returns a context object wrapping either the given file or


### PR DESCRIPTION
Some libraries (in my case [playwright](https://github.com/microsoft/playwright-python)) try to access `sys.<stdout|stderr>.closed` which raises an error if run in a Dramatiq actor. This fixes that.

I haven't written any tests because this is such a small change and I do not see any existing tests for `StreamablePipe`. However, let me know if you'd like me to add one.

P.S. I'm really loving Dramatiq! Thank you for all your work