### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,10 @@ setup(
     version=version,
     author="Bogdan Popa",
     author_email="bogdan@cleartype.io",
+    project_urls={
+        "Documentation": "https://dramatiq.io",
+        "Source": "https://github.com/Bogdanp/dramatiq",
+    },
     description="Background Processing for Python 3.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)