### PR TITLE
fix: race condition on join() in the redis broker.

### DIFF
--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -231,11 +231,7 @@ class RedisBroker(Broker):
             if deadline and time.monotonic() >= deadline:
                 raise QueueJoinTimeout(queue_name)
 
-            size = 0
-            # The delay queue needs to be checked before the normal queue.
-            # See https://github.com/Bogdanp/dramatiq/issues/480 for details.
-            for name in (dq_name(queue_name), queue_name):
-                size += self.do_qsize(name)
+            size = self.do_qsize(queue_name)
 
             if size == 0:
                 return

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -232,7 +232,9 @@ class RedisBroker(Broker):
                 raise QueueJoinTimeout(queue_name)
 
             size = 0
-            for name in (queue_name, dq_name(queue_name)):
+            # The delay queue needs to be checked before the normal queue.
+            # See https://github.com/Bogdanp/dramatiq/issues/480 for details.
+            for name in (dq_name(queue_name), queue_name):
                 size += self.do_qsize(name)
 
             if size == 0:

--- a/dramatiq/brokers/redis/dispatch.lua
+++ b/dramatiq/brokers/redis/dispatch.lua
@@ -229,8 +229,17 @@ elseif command == "purge" then
     redis.call("del", queue_full_name, queue_acks, queue_messages, xqueue_full_name, xqueue_messages)
 
 
--- Used in tests to determine the size of the queue.
+-- Used in tests to determine the size of the queue and its connected delay queue.
 elseif command == "qsize" then
-    return redis.call("hlen", queue_messages) + redis.call("scard", queue_acks)
+    local q_aks = acks .. "." .. queue_canonical_name
+    local q_fn = namespace .. ":" .. queue_canonical_name
+    local q_msgs = q_fn .. ".msgs"
+    local dq_q_aks = q_aks .. ".DQ"
+    local dq_q_msgs = q_fn .. ".DQ" .. ".msgs"
+
+    return redis.call("hlen", dq_q_msgs) +
+           redis.call("scard", dq_q_aks) +
+           redis.call("hlen", q_msgs) +
+           redis.call("scard", q_aks)
 
 end

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -496,40 +496,28 @@ def test_redis_join_race_condition(redis_broker, redis_worker):
     """
     test for issue https://github.com/Bogdanp/dramatiq/issues/480
 
-    this test was triggered a race condition when ``qsize`` returned only the size of the
-    requested queue, not also of the delay queue.
+    this test verifies that do_qsize counts all messages in the queue and delay queue at the same
+    time, removing the race condition mentioned in the issue
     """
-    old_qsize = redis_broker.do_qsize
-    events = defaultdict(threading.Event)
-
-    class M(dramatiq.Middleware):
-        def before_enqueue(self, broker, message, delay):
-            if not delay:
-                events["default"].set()
-                events["default_done"].wait(2)
-
-        def after_ack(self, broker, message):
-            if message.options.get("eta"):
-                events[dq_name("default")].set()
-
-    def qsize(qn):
-        events[qn].wait(2)
-        events[qn].clear()
-        res = old_qsize(qn)
-        events[f"{qn}_done"].set()
-        return res
-
-    redis_broker.add_middleware(M())
-    redis_broker.do_qsize = qsize
     called = False
+    size = []
 
     @dramatiq.actor
     def go():
+        go_again.send_with_options(delay=50)
+        size.append(redis_broker.do_qsize('default'))  # go ack + go msg + go_again msg
+        size.append(redis_broker.do_qsize(dq_name('default')))  # does the same
+
+    @dramatiq.actor
+    def go_again():
         nonlocal called
         called = True
+        size.append(redis_broker.do_qsize('default'))  # go_again msg + go_again ack
+        size.append(redis_broker.do_qsize(dq_name('default')))  # does the same
 
-    go.send_with_options(delay=50)
+    go.send()
     redis_broker.join("default")
     redis_worker.join()
 
     assert called
+    assert size == [3, 3, 2, 2]

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -493,7 +493,12 @@ def test_redis_consumer_nack_does_not_raise_on_missing_id(redis_worker):
 
 
 def test_redis_join_race_condition(redis_broker, redis_worker):
-    "test for issue https://github.com/Bogdanp/dramatiq/issues/480"
+    """
+    test for issue https://github.com/Bogdanp/dramatiq/issues/480
+
+    this test was triggered a race condition when ``qsize`` returned only the size of the
+    requested queue, not also of the delay queue.
+    """
     old_qsize = redis_broker.do_qsize
     events = defaultdict(threading.Event)
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -500,18 +500,18 @@ def test_redis_join_race_condition(redis_broker, redis_worker):
     class M(dramatiq.Middleware):
         def before_enqueue(self, broker, message, delay):
             if not delay:
-                events['default'].set()
-                events['default_done'].wait(2)
+                events["default"].set()
+                events["default_done"].wait(2)
 
         def after_ack(self, broker, message):
             if message.options.get("eta"):
-                events[dq_name('default')].set()
+                events[dq_name("default")].set()
 
     def qsize(qn):
         events[qn].wait(2)
         events[qn].clear()
         res = old_qsize(qn)
-        events[f'{qn}_done'].set()
+        events[f"{qn}_done"].set()
         return res
 
     redis_broker.add_middleware(M())
@@ -524,7 +524,7 @@ def test_redis_join_race_condition(redis_broker, redis_worker):
         called = True
 
     go.send_with_options(delay=50)
-    redis_broker.join('default')
+    redis_broker.join("default")
     redis_worker.join()
 
     assert called

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,6 +1,4 @@
-import threading
 import time
-from collections import defaultdict
 from unittest import mock
 
 import pytest
@@ -505,15 +503,15 @@ def test_redis_join_race_condition(redis_broker, redis_worker):
     @dramatiq.actor
     def go():
         go_again.send_with_options(delay=50)
-        size.append(redis_broker.do_qsize('default'))  # go ack + go msg + go_again msg
-        size.append(redis_broker.do_qsize(dq_name('default')))  # does the same
+        size.append(redis_broker.do_qsize("default"))  # go ack + go msg + go_again msg
+        size.append(redis_broker.do_qsize(dq_name("default")))  # does the same
 
     @dramatiq.actor
     def go_again():
         nonlocal called
         called = True
-        size.append(redis_broker.do_qsize('default'))  # go_again msg + go_again ack
-        size.append(redis_broker.do_qsize(dq_name('default')))  # does the same
+        size.append(redis_broker.do_qsize("default"))  # go_again msg + go_again ack
+        size.append(redis_broker.do_qsize(dq_name("default")))  # does the same
 
     go.send()
     redis_broker.join("default")

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -502,7 +502,7 @@ def test_redis_join_race_condition(redis_broker, redis_worker):
 
     @dramatiq.actor
     def go():
-        go_again.send_with_options(delay=50)
+        go_again.send_with_options(delay=1000)
         size.append(redis_broker.do_qsize("default"))  # go ack + go msg + go_again msg
         size.append(redis_broker.do_qsize(dq_name("default")))  # does the same
 


### PR DESCRIPTION
This fixes #480 

I'm not sure how to test this, since the race condition is not easy to trigger. @Bogdanp do you have any suggestions?

Also looking at the stub broker it seems that it may have a similar race condition, but I've never triggered a similar issue with it, so I'm not sure if the change (swapping the order or the delay queue and normal one) is needed
https://github.com/Bogdanp/dramatiq/blob/2d0ca2519a0289946337b308e450a915cf5fd869/dramatiq/brokers/stub.py#L153-L164