### PR TITLE
Fix an incorrect type annotation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,3 +53,4 @@ of those changes to CLEARTYPE SRL.
 | [@ethervoid](https://github.com/ethervoid)            | Mario de Frutos        |
 | [@pcrockett](https://github.com/pcrockett)            | Phil Crockett          |
 | [@nathanielobrown](https://github.com/nathanielobrown)| Nathaniel Brown        |
+| [@kurtmckee](https://github.com/kurtmckee)            | Kurt McKee             |

--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -102,7 +102,7 @@ class Actor:
         """Asynchronously send a message to this actor.
 
         Parameters:
-          *args(tuple): Positional arguments to send to the actor.
+          *args: Positional arguments to send to the actor.
           **kwargs: Keyword arguments to send to the actor.
 
         Returns:


### PR DESCRIPTION
`args` is accessed as a tuple, but `*args` must be annotated according to its individual argument types, like `Any` or `Union[str, int]`.

The annotation as it currently stands causes code linter warnings.