### PR TITLE
Emit signal before call dramatiq.Consumer.consume

### DIFF
--- a/dramatiq/middleware/middleware.py
+++ b/dramatiq/middleware/middleware.py
@@ -153,3 +153,8 @@ class Middleware:
 
         There is no ``after_worker_thread_boot``.
         """
+
+    def before_broker_consume(self, broker, thread):
+        """Called before a consumer thread starts consuming messages. This may
+        be used to pause and resume consumer threads.
+        """

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -247,7 +247,11 @@ class _ConsumerThread(Thread):
     def run(self):
         self.logger.debug("Running consumer thread...")
         self.running = True
+
         while self.running:
+
+            self.broker.emit_before("broker_consume", self)
+
             if self.paused:
                 self.logger.debug("Consumer is paused. Sleeping for %.02fms...", self.worker_timeout)
                 self.paused_event.set()


### PR DESCRIPTION
Emit signal befora call `self.broker.consume`.

This idea is to solve this problem #472. 

Before consuming the queue I can define through rules on my system if it is able or not by calling `thread.stop()` in a middleware.