### PR TITLE
docs: Fix a few typos

### DIFF
--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -174,7 +174,7 @@ class Worker:
             self.work_queue.join()
 
             # If nothing got put on the delay queues while we were
-            # joining on the work queue then it shoud be safe to exit.
+            # joining on the work queue then it should be safe to exit.
             # This could still miss stuff but the chances are slim.
             for consumer in self.consumers.values():
                 if consumer.delay_queue.unfinished_tasks:

--- a/tests/test_concurrent_rate_limiter.py
+++ b/tests/test_concurrent_rate_limiter.py
@@ -44,7 +44,7 @@ def test_concurrent_rate_limiter_can_act_as_a_mutex(rate_limiter_backend):
         for future in futures:
             future.result()
 
-    # I exepct only one call to have succeeded
+    # I expect only one call to have succeeded
     assert sum(calls) == 1
 
 


### PR DESCRIPTION
There are small typos in:
- dramatiq/worker.py
- tests/test_concurrent_rate_limiter.py

Fixes:
- Should read `should` rather than `shoud`.
- Should read `expect` rather than `exepct`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md