### PR TITLE
fix: Avoid warning on missing dependencies when those dependencies are used.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,3 +56,4 @@ of those changes to CLEARTYPE SRL.
 | [@staticdev](https://github.com/staticdev)            | Thiago                 |
 | [@kurtmckee](https://github.com/kurtmckee)            | Kurt McKee             |
 | [@cmflynn](https://github.com/cmflynn)                | Cody Flynn             |
+| [@dancardin](https://github.com/dancardin)            | Dan Cardin             |

--- a/dramatiq/results/backends/__init__.py
+++ b/dramatiq/results/backends/__init__.py
@@ -19,20 +19,46 @@ import warnings
 
 from .stub import StubBackend
 
-try:
-    from .memcached import MemcachedBackend
-except ImportError:  # pragma: no cover
-    warnings.warn(
-        "MemcachedBackend is not available.  Run `pip install dramatiq[memcached]` "
-        "to add support for that backend.", ImportWarning,
-    )
-
-try:
-    from .redis import RedisBackend
-except ImportError:  # pragma: no cover
-    warnings.warn(
-        "RedisBackend is not available.  Run `pip install dramatiq[redis]` "
-        "to add support for that backend.", ImportWarning,
-    )
-
 __all__ = ["StubBackend", "MemcachedBackend", "RedisBackend"]
+
+
+def __getattr__(name):
+    module_importer = _module_importers.get(name)
+    if module_importer is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    return module_importer()
+
+
+def import_memcached():
+    try:
+        from .memcached import MemcachedBackend
+
+        return MemcachedBackend
+    except ModuleNotFoundError:
+        warning = ImportWarning(
+            "MemcachedBackend is not available.  Run `pip install dramatiq[memcached]` "
+            "to add support for that backend.",
+        )
+        warnings.warn(warning)
+        raise
+
+
+def import_redis():
+    try:
+        from .redis import RedisBackend
+
+        return RedisBackend
+    except ModuleNotFoundError:
+        warning = ImportWarning(
+            "RedisBackend is not available.  Run `pip install dramatiq[redis]` "
+            "to add support for that backend.",
+        )
+        warnings.warn(warning)
+        raise
+
+
+_module_importers = {
+    "MemcachedBackend": import_memcached,
+    "RedisBackend": import_redis,
+}


### PR DESCRIPTION
Defer imports of backend client libraries until the backend is instantiated. This should maintain the existing failure behavior which lazily causes usages of missing backends to fail. However it defers the emission of warnings on unused backends **until** they're instantiated

Addresses https://github.com/Bogdanp/dramatiq/issues/421

This is perhaps somewhat of an suboptimal way of "fixing" the problem, but due to lack of response on the issue, I opted for an option with perhaps the least chance of it breaking existing users, since you expose both RedisBackend/MemcachedBackend throught `__all__` which arguably makes them part of your expected public interface.

I'm happy to adjust to other options if this isn't how you'd ideally fix it.