### PR TITLE
Annotate types for Actor and Message

### DIFF
--- a/dramatiq/encoder.py
+++ b/dramatiq/encoder.py
@@ -70,5 +70,8 @@ class PickleEncoder(Encoder):
       Use it at your own risk.
     """
 
-    encode = pickle.dumps
-    decode = pickle.loads
+    def encode(self, data: MessageData) -> bytes:
+        return pickle.dumps(data)
+
+    def decode(self, data: bytes) -> MessageData:
+        return pickle.loads(data)

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -26,7 +26,7 @@ from .errors import DecodeError
 from .results import Results
 
 #: The global encoder instance.
-global_encoder = JSONEncoder()
+global_encoder: Encoder = JSONEncoder()
 
 
 def get_encoder() -> Encoder:

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -18,6 +18,7 @@
 import time
 import uuid
 from collections import namedtuple
+from typing import Optional
 
 from .broker import get_broker
 from .composition import pipeline
@@ -39,7 +40,7 @@ def get_encoder() -> Encoder:
     return global_encoder
 
 
-def set_encoder(encoder: Encoder):
+def set_encoder(encoder: Encoder) -> None:
     """Set the global encoder object.
 
     Parameters:
@@ -85,13 +86,13 @@ class Message(namedtuple("Message", (
         """
         return pipeline([self, other])
 
-    def asdict(self):
+    def asdict(self) -> dict:
         """Convert this message to a dictionary.
         """
         return self._asdict()
 
     @classmethod
-    def decode(cls, data):
+    def decode(cls, data: bytes) -> "Message":
         """Convert a bytestring to a message.
 
         Raises:
@@ -103,12 +104,12 @@ class Message(namedtuple("Message", (
         except Exception as e:
             raise DecodeError("Failed to decode message.", data, e) from e
 
-    def encode(self):
+    def encode(self) -> bytes:
         """Convert this message to a bytestring.
         """
         return global_encoder.encode(self._asdict())
 
-    def copy(self, **attributes):
+    def copy(self, **attributes) -> "Message":
         """Create a copy of this message.
         """
         updated_options = attributes.pop("options", {})
@@ -116,7 +117,12 @@ class Message(namedtuple("Message", (
         options.update(updated_options)
         return self._replace(**attributes, options=options)
 
-    def get_result(self, *, backend=None, block=False, timeout=None):
+    def get_result(
+        self, *,
+        backend=None,
+        block: bool = False,
+        timeout: Optional[int] = None,
+    ):
         """Get the result associated with this message from a result
         backend.
 
@@ -154,7 +160,7 @@ class Message(namedtuple("Message", (
 
         return backend.get_result(self, block=block, timeout=timeout)
 
-    def __str__(self):
+    def __str__(self) -> str:
         params = ", ".join(repr(arg) for arg in self.args)
         if self.kwargs:
             params += ", " if params else ""

--- a/dramatiq/middleware/shutdown.py
+++ b/dramatiq/middleware/shutdown.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import threading
+from typing import Optional, Type
 import warnings
 
 from ..logging import get_logger
@@ -86,7 +87,22 @@ class ShutdownNotifications(Middleware):
     after_skip_message = after_process_message
 
 
-class _CtypesShutdownManager:
+class _ShutdownManager:
+
+    def __init__(self, logger=None) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def add_notification(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def remove_notification(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def shutdown(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+
+class _CtypesShutdownManager(_ShutdownManager):
 
     def __init__(self, logger=None):
         self.logger = logger or get_logger(__name__, type(self))
@@ -104,11 +120,11 @@ class _CtypesShutdownManager:
             raise_thread_exception(thread_id, Shutdown)
 
 
-_GeventShutdownManager = None
+_GeventShutdownManager: Optional[Type[_ShutdownManager]] = None
 if is_gevent_active():
     from gevent import getcurrent
 
-    class _GeventShutdownManager:
+    class __GeventShutdownManager(_ShutdownManager):
 
         def __init__(self, logger=None):
             self.logger = logger or get_logger(__name__, type(self))
@@ -130,3 +146,5 @@ if is_gevent_active():
             for thread_id, greenlet in self.notification_greenlets:
                 self.logger.info("Worker shutdown notification. Raising exception in worker thread %r.", thread_id)
                 greenlet.kill(Shutdown, block=False)
+
+    _GeventShutdownManager = __GeventShutdownManager

--- a/dramatiq/middleware/shutdown.py
+++ b/dramatiq/middleware/shutdown.py
@@ -16,8 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import threading
-from typing import Optional, Type
 import warnings
+from typing import Optional, Type
 
 from ..logging import get_logger
 from .middleware import Middleware

--- a/dramatiq/middleware/time_limit.py
+++ b/dramatiq/middleware/time_limit.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import threading
+from typing import TYPE_CHECKING, Optional
 import warnings
 from threading import Thread
 from time import monotonic, sleep
@@ -23,6 +24,10 @@ from time import monotonic, sleep
 from ..logging import get_logger
 from .middleware import Middleware
 from .threading import Interrupt, current_platform, is_gevent_active, raise_thread_exception, supported_platforms
+
+
+if TYPE_CHECKING:
+    import gevent
 
 
 class TimeLimitExceeded(Interrupt):
@@ -145,11 +150,11 @@ class _GeventTimeoutManager:
             timer.close()
 
 
-_GeventTimeout = None
+_GeventTimeout: Optional["gevent.Timeout"] = None
 if is_gevent_active():
     from gevent import Timeout
 
-    class _GeventTimeout(Timeout):
+    class __GeventTimeout(Timeout):
         """Cooperative timeout class for gevent with logging on timeouts."""
 
         def __init__(self, *args, logger=None, thread_id=None, after_expiration=None, **kwargs):
@@ -165,3 +170,5 @@ if is_gevent_active():
             if self.after_expiration is not None:
                 self.after_expiration()
             return res
+
+    _GeventTimeout = __GeventTimeout

--- a/dramatiq/middleware/time_limit.py
+++ b/dramatiq/middleware/time_limit.py
@@ -16,15 +16,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import threading
-from typing import TYPE_CHECKING, Optional
 import warnings
 from threading import Thread
 from time import monotonic, sleep
+from typing import TYPE_CHECKING, Optional
 
 from ..logging import get_logger
 from .middleware import Middleware
 from .threading import Interrupt, current_platform, is_gevent_active, raise_thread_exception, supported_platforms
-
 
 if TYPE_CHECKING:
     import gevent

--- a/dramatiq/results/backend.py
+++ b/dramatiq/results/backend.py
@@ -37,7 +37,7 @@ Missing = type("Missing", (object,), {})()
 Result = typing.Any
 
 #: A union representing a Result that may or may not be there.
-MResult = typing.Union[type(Missing), Result]
+MResult = typing.Union[typing.Type[object], Result]
 
 
 class ResultBackend:
@@ -50,7 +50,7 @@ class ResultBackend:
         result data.  Defaults to :class:`.JSONEncoder`.
     """
 
-    def __init__(self, *, namespace: str = "dramatiq-results", encoder: Encoder = None):
+    def __init__(self, *, namespace: str = "dramatiq-results", encoder: typing.Optional[Encoder] = None):
         from ..message import get_encoder
 
         self.namespace = namespace
@@ -70,7 +70,7 @@ class ResultBackend:
         """
         return unwrap_result(res)
 
-    def get_result(self, message, *, block: bool = False, timeout: int = None) -> Result:
+    def get_result(self, message, *, block: bool = False, timeout: typing.Optional[int] = None) -> Result:
         """Get a result from the backend.
 
         Parameters:


### PR DESCRIPTION
1. Fix existing type violations reported by mypy.
2. Annotate types for `Actor`, `actor`, and `Message`
3. Use TypeVar with Generic to propagate the return type of the function. For example, if you wrap a function that returns `str`, then mypy will know that calling `Actor` instance also returns `str`.

Something that can be improved later:

1. `Message` is a namedtuple, and so cannot inherit from Generic. It can be solved by using a dataclass instead.
2. Types for arguments of the function can be typed with [Parameter Specification Variables](https://peps.python.org/pep-0612/), but for that, you'll need [typing-extensions](https://pypi.org/project/typing-extensions/) the good news is that it can be static-only dependency by putting it inside of `if TYPE_CHECKING`. But I didn't want to complicate this PR too much.
