### PR TITLE
Use ParamSpec to type check Actor args

### DIFF
--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
     P = ParamSpec("P")
+else:
+    P = TypeVar("P")
 
 #: The regular expression that represents valid queue names.
 _queue_name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9._-]*")
@@ -35,7 +37,7 @@ _queue_name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9._-]*")
 R = TypeVar("R")
 
 
-class Actor(Generic["P", R]):
+class Actor(Generic[P, R]):
     """Thin wrapper around callables that stores metadata about how
     they should be executed asynchronously.  Actors are callable.
 

--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -190,7 +190,7 @@ def actor(fn: Callable[P, R], **kwargs) -> Actor[P, R]:
 
 
 @overload
-def actor(fn: None, **kwargs) -> Callable[[Callable[P, R]], Actor[P, R]]:
+def actor(fn: None = None, **kwargs) -> Callable[[Callable[P, R]], Actor[P, R]]:
     pass
 
 

--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -14,14 +14,20 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
 
 import re
 import time
-from typing import Any, Callable, Dict, Generic, Optional, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Optional, TypeVar, Union, overload
 
 from .broker import Broker, get_broker
 from .logging import get_logger
 from .message import Message
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")
 
 #: The regular expression that represents valid queue names.
 _queue_name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9._-]*")
@@ -29,7 +35,7 @@ _queue_name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9._-]*")
 R = TypeVar("R")
 
 
-class Actor(Generic[R]):
+class Actor(Generic["P", R]):
     """Thin wrapper around callables that stores metadata about how
     they should be executed asynchronously.  Actors are callable.
 
@@ -46,7 +52,7 @@ class Actor(Generic[R]):
 
     def __init__(
         self,
-        fn: Callable[..., R],
+        fn: Callable[P, R],
         *,
         broker: Broker,
         actor_name: str,
@@ -63,7 +69,7 @@ class Actor(Generic[R]):
         self.options = options
         self.broker.declare_actor(self)
 
-    def message(self, *args, **kwargs) -> Message[R]:
+    def message(self, *args: P.args, **kwargs: P.kwargs) -> Message[R]:
         """Build a message.  This method is useful if you want to
         compose actors.  See the actor composition documentation for
         details.
@@ -116,7 +122,7 @@ class Actor(Generic[R]):
             options=options,
         )
 
-    def send(self, *args, **kwargs) -> Message[R]:
+    def send(self, *args: P.args, **kwargs: P.kwargs) -> Message[R]:
         """Asynchronously send a message to this actor.
 
         Parameters:
@@ -153,7 +159,7 @@ class Actor(Generic[R]):
         message = self.message_with_options(args=args, kwargs=kwargs, **options)
         return self.broker.enqueue(message, delay=delay)
 
-    def __call__(self, *args, **kwargs) -> R:
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         """Synchronously call this actor.
 
         Parameters:
@@ -179,25 +185,25 @@ class Actor(Generic[R]):
 
 
 @overload
-def actor(fn: Callable[..., R], **kwargs) -> Actor[R]:
+def actor(fn: Callable[P, R], **kwargs) -> Actor[P, R]:
     pass
 
 
 @overload
-def actor(**kwargs) -> Callable[[Callable[..., R]], Actor[R]]:
+def actor(fn: None, **kwargs) -> Callable[[Callable[P, R]], Actor[P, R]]:
     pass
 
 
 def actor(
-    fn: Optional[Callable[..., R]] = None,
+    fn: Optional[Callable[P, R]] = None,
     *,
-    actor_class: Callable[..., Actor[R]] = Actor,
+    actor_class: Callable[..., Actor[P, R]] = Actor,  # type: ignore[assignment]
     actor_name: Optional[str] = None,
     queue_name: str = "default",
     priority: int = 0,
     broker: Optional[Broker] = None,
     **options,
-) -> Union[Actor, Callable]:
+) -> Union[Actor[P, R], Callable]:
     """Declare an actor.
 
     Examples:
@@ -240,7 +246,7 @@ def actor(
     Returns:
       Actor: The decorated function.
     """
-    def decorator(fn: Callable[..., R]) -> Actor[R]:
+    def decorator(fn: Callable[..., R]) -> Actor[P, R]:
         nonlocal actor_name, broker
         actor_name = actor_name or fn.__name__
         if not _queue_name_re.fullmatch(queue_name):


### PR DESCRIPTION
The PR introduces ParamSpec ([PEP 612](https://peps.python.org/pep-0612/)) to type annotate that `Actor.__call__` and similar expect all the same arguments as the wrapped handler function. A few clarifications on the black magic that happening:

1. I import ParamSpec from [typing-extensions](https://pypi.org/project/typing-extensions/) to be compatible with all Python versions.
2. I have this import and ParamSpec definition inside of `if TYPE_CHECKING` block, so dramatiq doesn't depend on typing-extensions at runtime. At static type checking time by mypy, typing-extensions are guaranteed to be available because they are a dependency of mypy (and pyright has their stubs bundled).
3. I added `from __future__ import annotations`, so that imports are lazy. See [PEP 563](https://peps.python.org/pep-0563/). I've added it because initially I made it so that ParamSpec is not available at runtime. I later had to mock it for runtime (see the next point) but decided to leave this lazy annotations hack, it's quite handy on its own for many reasons.
4. `Generic` is a base class, not an annotation, and so its arguments are evaluated at runtime. I tried to pass the ParamSpec as a string, but then it explodes inruntime with TypeError. So, I replace `ParamSpec` with `TypeVar` in runtime.
5. ParamSpec can be used only with `*args` and `**kwargs`, so `message_with_options` and `send_with_options` cannot be annotated.
