### PR TITLE
Fix tests broken by moving Message to dataclass

### DIFF
--- a/dramatiq/composition.py
+++ b/dramatiq/composition.py
@@ -52,9 +52,8 @@ class pipeline:
             else:
                 messages.append(child.copy())
 
-        rev = messages[::-1]
-        for message, prev_message in zip(rev, rev[1:]):
-            prev_message.options["pipe_target"] = message.asdict()
+        for message, next_message in zip(messages, messages[1:]):
+            message.options["pipe_target"] = next_message.asdict()
 
     def __len__(self):
         """Returns the length of the pipeline.

--- a/dramatiq/composition.py
+++ b/dramatiq/composition.py
@@ -14,13 +14,18 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING, Iterable
 from uuid import uuid4
 
 from .broker import get_broker
 from .rate_limits import Barrier
 from .results import ResultMissing
+
+if TYPE_CHECKING:
+    from .message import Message
 
 
 class pipeline:
@@ -34,9 +39,11 @@ class pipeline:
       broker(Broker): The broker to run the pipeline on.  Defaults to
         the current global broker.
     """
+    messages: list[Message]
 
-    def __init__(self, children, *, broker=None):
+    def __init__(self, children: Iterable[Message | pipeline], *, broker=None):
         self.broker = broker or get_broker()
+        messages: list[Message]
         self.messages = messages = []
 
         for child in children:
@@ -45,8 +52,9 @@ class pipeline:
             else:
                 messages.append(child.copy())
 
-        for message, next_message in zip(messages, messages[1:]):
-            message.options["pipe_target"] = next_message.asdict()
+        rev = messages[::-1]
+        for message, prev_message in zip(rev, rev[1:]):
+            prev_message.options["pipe_target"] = message.asdict()
 
     def __len__(self):
         """Returns the length of the pipeline.

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -100,7 +100,9 @@ class Message(Generic[R]):
             decoding `data`.
         """
         try:
-            return cls(**global_encoder.decode(data))
+            fields = global_encoder.decode(data)
+            fields["args"] = tuple(fields["args"])
+            return cls(**fields)
         except Exception as e:
             raise DecodeError("Failed to decode message.", data, e) from e
 
@@ -165,3 +167,6 @@ class Message(Generic[R]):
             params += ", ".join("%s=%r" % (name, value) for name, value in self.kwargs.items())
 
         return "%s(%s)" % (self.actor_name, params)
+
+    def __lt__(self, other: "Message") -> bool:
+        return dataclasses.astuple(self) < dataclasses.astuple(other)

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -89,7 +89,12 @@ class Message(Generic[R]):
     def asdict(self) -> Dict[str, Any]:
         """Convert this message to a dictionary.
         """
-        return dataclasses.asdict(self)
+        # For backward compatibility, we can't use `dataclasses.asdict`
+        # because it creates a copy of all values, including `options`.
+        result = {}
+        for field in dataclasses.fields(self):
+            result[field.name] = getattr(self, field.name)
+        return result
 
     @classmethod
     def decode(cls, data: bytes) -> "Message":


### PR DESCRIPTION
The changes in #513 broke tests a bit that relied on Message being a namedtuple, see comment https://github.com/Bogdanp/dramatiq/pull/513#issuecomment-1342164116 by @anton-petrov.

1. Add `pipe_target` into `Message.options` inside of `pipeline` in the reverse order, so that the message dump inside `pipe_target` recursively contains `pipe_target` of the next message.
2. Add `Message.__lt__`, so that messages can be sorted. The sorting order is the same as it was for namedtuple.
3. Make sure `Message.args` is a tuple when restoring from a dump.