### PR TITLE
Add a release GHA workflow using 'build'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: PyPI release
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: python -m pip install build
+
+      - name: Build dist packages
+        run: python -m build .
+
+      - name: Upload packages to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
- release-published triggers a release to PyPI
- the build is done via pypa's `build` which provides a generic build frontend even if the project moves off of setuptools in the future
- upload is done by the pypa-provided github action

References:
- #531 motivated this
- credit to @amureki for the original workflow on which this is modeled