### PR TITLE
Support asynchronous (asyncio) contexts in actors

### DIFF
--- a/dramatiq/middleware/asyncio.py
+++ b/dramatiq/middleware/asyncio.py
@@ -1,0 +1,152 @@
+import asyncio
+import threading
+import time
+from concurrent.futures import TimeoutError
+from typing import Awaitable, Optional
+
+import dramatiq
+from dramatiq.middleware import Middleware
+
+from ..logging import get_logger
+from .threading import Interrupt
+
+__all__ = ["AsyncActor", "AsyncMiddleware", "async_actor"]
+
+
+class EventLoopThread(threading.Thread):
+    """A thread that runs an asyncio event loop.
+
+    The method 'run_coroutine' should be used to run coroutines from a
+    synchronous context.
+    """
+
+    # seconds to wait for the event loop to start
+    EVENT_LOOP_START_TIMEOUT = 0.1
+    # interval (seconds) to reactivate the worker thread and check
+    # for interrupts
+    INTERRUPT_CHECK_INTERVAL = 1.0
+
+    loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def __init__(self, logger):
+        self.logger = logger
+        super().__init__(target=self._start_event_loop)
+
+    def _start_event_loop(self):
+        """This method should run in the thread"""
+        self.logger.info("Starting the event loop...")
+
+        self.loop = asyncio.new_event_loop()
+        try:
+            self.loop.run_forever()
+        finally:
+            self.loop.close()
+
+    def _stop_event_loop(self):
+        """This method should run outside of the thread"""
+        if self.loop is not None and self.loop.is_running():
+            self.logger.info("Stopping the event loop...")
+            self.loop.call_soon_threadsafe(self.loop.stop)
+
+    def run_coroutine(self, coro: Awaitable) -> None:
+        """To be called from outside the thread
+
+        Blocks until the coroutine is finished.
+        """
+        if self.loop is None or not self.loop.is_running():
+            raise RuntimeError("The event loop is not running")
+        future = asyncio.run_coroutine_threadsafe(coro, self.loop)
+        while True:
+            try:
+                # Use a timeout to be able to catch asynchronously raised dramatiq
+                # exceptions (Interrupt).
+                future.result(timeout=self.INTERRUPT_CHECK_INTERVAL)
+            except Interrupt:
+                # Asynchronously raised from another thread: cancel the future and
+                # reiterate to wait for possible cleanup actions.
+                self.loop.call_soon_threadsafe(future.cancel)
+            except TimeoutError:
+                continue
+
+            break
+
+    def start(self, *args, **kwargs):
+        super().start(*args, **kwargs)
+        time.sleep(self.EVENT_LOOP_START_TIMEOUT)
+        if self.loop is None or not self.loop.is_running():
+            raise RuntimeError("The event loop failed to start")
+        self.logger.info("Event loop is running.")
+
+    def join(self, *args, **kwargs):
+        self._stop_event_loop()
+        return super().join(*args, **kwargs)
+
+
+class AsyncMiddleware(Middleware):
+    """This middleware manages the event loop thread.
+
+    This thread is used to schedule coroutines on from the worker threads.
+    """
+
+    event_loop_thread: Optional[EventLoopThread] = None
+
+    def __init__(self):
+        self.logger = get_logger(__name__, type(self))
+
+    def run_coroutine(self, coro: Awaitable) -> None:
+        self.event_loop_thread.run_coroutine(coro)
+
+    def before_worker_boot(self, broker, worker):
+        self.event_loop_thread = EventLoopThread(self.logger)
+        self.event_loop_thread.start()
+
+        # Monkeypatch the broker to make the event loop thread reachable
+        # from an actor or from other middleware.
+        broker.run_coroutine = self.event_loop_thread.run_coroutine
+
+    def after_worker_shutdown(self, broker, worker):
+        self.event_loop_thread.join()
+        self.event_loop_thread = None
+
+        delattr(broker, "run_coroutine")
+
+
+class AsyncActor(dramatiq.Actor):
+    """To configure coroutines as a dramatiq actor.
+
+    Requires AsyncMiddleware to be active.
+
+    Example usage:
+
+    >>> @dramatiq.actor(..., actor_class=AsyncActor)
+    ... async def my_task(x):
+    ...     print(x)
+
+    Notes:
+
+    The coroutine is scheduled on an event loop that is shared between
+    worker threads. See AsyncMiddleware and EventLoopThread.
+
+    This is compatible with ShutdownNotifications ("notify_shutdown") and
+    TimeLimit ("time_limit"). Both result in an asyncio.CancelledError raised inside
+    the async function. There is currently no way to tell the two apart from
+    within the coroutine.
+    """
+
+    def __init__(self, fn, *args, **kwargs):
+        super().__init__(
+            lambda *args, **kwargs: self.broker.run_coroutine(fn(*args, **kwargs)),
+            *args,
+            **kwargs
+        )
+
+
+def async_actor(awaitable=None, **kwargs):
+    if awaitable is not None:
+        return dramatiq.actor(awaitable, actor_class=AsyncActor, **kwargs)
+    else:
+
+        def wrapper(awaitable):
+            return dramatiq.actor(awaitable, actor_class=AsyncActor, **kwargs)
+
+        return wrapper

--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -1,0 +1,111 @@
+import asyncio
+import threading
+from unittest import mock
+
+import pytest
+
+from dramatiq.middleware.asyncio import AsyncActor, AsyncMiddleware, EventLoopThread, async_actor
+
+
+@pytest.fixture
+def started_thread():
+    thread = EventLoopThread(logger=mock.Mock())
+    thread.start()
+    yield thread
+    thread.join()
+
+
+@pytest.fixture
+def logger():
+    return mock.Mock()
+
+
+def test_event_loop_thread_start():
+    try:
+        thread = EventLoopThread(logger=mock.Mock())
+        thread.start()
+        assert isinstance(thread.loop, asyncio.BaseEventLoop)
+        assert thread.loop.is_running()
+    finally:
+        thread.join()
+
+
+def test_event_loop_thread_run_coroutine(started_thread: EventLoopThread):
+    result = {}
+
+    async def get_thread_id():
+        result["thread_id"] = threading.get_ident()
+
+    started_thread.run_coroutine(get_thread_id())
+
+    # the coroutine executed in the event loop thread
+    assert result["thread_id"] == started_thread.ident
+
+
+def test_event_loop_thread_run_coroutine_exception(started_thread: EventLoopThread):
+    async def raise_error():
+        raise TypeError("bla")
+
+    coro = raise_error()
+
+    with pytest.raises(TypeError, match="bla"):
+        started_thread.run_coroutine(coro)
+
+
+@mock.patch.object(EventLoopThread, "start")
+@mock.patch.object(EventLoopThread, "run_coroutine")
+def test_async_middleware_before_worker_boot(
+    EventLoopThread_run_coroutine, EventLoopThread_start
+):
+    broker = mock.Mock()
+    worker = mock.Mock()
+    middleware = AsyncMiddleware()
+
+    middleware.before_worker_boot(broker, worker)
+
+    assert isinstance(middleware.event_loop_thread, EventLoopThread)
+
+    EventLoopThread_start.assert_called_once()
+
+    middleware.run_coroutine("foo")
+    EventLoopThread_run_coroutine.assert_called_once_with("foo")
+
+    # broker was patched with run_coroutine
+    broker.run_coroutine("bar")
+    EventLoopThread_run_coroutine.assert_called_with("bar")
+
+
+def test_async_middleware_after_worker_shutdown():
+    broker = mock.Mock()
+    broker.run_coroutine = lambda x: x
+    worker = mock.Mock()
+    event_loop_thread = mock.Mock()
+
+    middleware = AsyncMiddleware()
+    middleware.event_loop_thread = event_loop_thread
+    middleware.after_worker_shutdown(broker, worker)
+
+    event_loop_thread.join.assert_called_once()
+    assert middleware.event_loop_thread is None
+    assert not hasattr(broker, "run_coroutine")
+
+
+def test_async_actor(started_thread):
+    broker = mock.Mock()
+    broker.actor_options = {"max_retries"}
+
+    @async_actor(broker=broker)
+    async def foo(*args, **kwargs):
+        pass
+
+    assert isinstance(foo, AsyncActor)
+
+    foo(2, a="b")
+
+    broker.run_coroutine.assert_called_once()
+
+    # no recursion errors here:
+    repr(foo)
+
+    # this is just to stop "never awaited" warnings
+    started_thread.run_coroutine(broker.run_coroutine.call_args[0][0])

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -482,3 +482,19 @@ def test_currrent_message_middleware_exposes_the_current_message(stub_broker, st
     # When I try to access the current message from a non-worker thread
     # Then I should get back None
     assert CurrentMessage.get_current_message() is None
+
+
+@patch("dramatiq.middleware.asyncio.async_to_sync")
+def test_actors_can_wrap_asyncio(async_to_sync_mock, stub_broker):
+    # Define an asyncio function and wrap it in an actor
+    async def add(x, y):
+        return x + y
+
+    actor = dramatiq.actor(add)
+
+    # I expect that function to become an instance of Actor
+    assert isinstance(actor, dramatiq.Actor)
+
+    # The wrapped function should be wrapped with 'async_to_sync'
+    async_to_sync_mock.assert_called_once_with(add)
+    assert actor.fn == async_to_sync_mock.return_value


### PR DESCRIPTION
Hi @Bogdanp 

Thanks for the great work on this package!

I ported some code from another project to support asyncio with dramatiq. Reading #238 I got the feeling there might be people wanting to use this. We ourselves have an async webserver, of which we wanted to use parts from a worker process, and `asgiref.sync_to_async` didn't play nice with `sqlalchemy`, so we made this.

The bottomline here is to have a single event loop thread *per worker process*. This `EventLoopThread` is spinned up from the `AsyncMiddleware`. If `AsyncMiddleware` is inplace, you can decorate coroutines with `@async_actor`. Worker threads then schedule on the event loop and wait for their tasks to finish. In this way, I didn't have to touch the dramatiq core code.

There are some points to discuss here, but first I'd like to know if @Bogdanp is :+1: on proceeding with this PR?