### PR TITLE
Fix “an interrupted (Cancelled) coroutine doesn't cleanup”

### DIFF
--- a/dramatiq/asyncio.py
+++ b/dramatiq/asyncio.py
@@ -171,10 +171,14 @@ class EventLoopThread(threading.Thread):
                     continue
                 else:
                     break
-        except Interrupt:
+        except Interrupt as e:
             # Asynchronously raised from another thread: cancel
-            # the future and reiterate to wait for possible
-            # cleanup actions.
+            # the future and wait for possible cleanup actions.
             self.loop.call_soon_threadsafe(task.cancel)
+            try:
+                future.result()
+            except asyncio.CancelledError:
+                pass
+            raise e  # raises Interrupt, not asyncio.CancelledError
 
         return future.result()

--- a/dramatiq/asyncio.py
+++ b/dramatiq/asyncio.py
@@ -171,14 +171,10 @@ class EventLoopThread(threading.Thread):
                     continue
                 else:
                     break
-        except Interrupt as e:
+        except Interrupt:
             # Asynchronously raised from another thread: cancel
-            # the future and wait for possible cleanup actions.
+            # the future and reiterate to wait for possible
+            # cleanup actions.
             self.loop.call_soon_threadsafe(task.cancel)
-            try:
-                future.result()
-            except asyncio.CancelledError:
-                pass
-            raise e  # raises Interrupt, not asyncio.CancelledError
 
         return future.result()

--- a/dramatiq/asyncio.py
+++ b/dramatiq/asyncio.py
@@ -20,7 +20,8 @@ import concurrent.futures
 import functools
 import logging
 import threading
-from typing import Awaitable, Callable, Optional, TypeVar
+from concurrent.futures import Future
+from typing import Awaitable, Callable, Optional, Tuple, TypeVar
 
 from .threading import Interrupt
 
@@ -28,7 +29,7 @@ __all__ = [
     "EventLoopThread",
     "async_to_sync",
     "get_event_loop_thread",
-    "set_event_loop_thread"
+    "set_event_loop_thread",
 ]
 
 R = TypeVar("R")
@@ -46,8 +47,7 @@ def get_event_loop_thread() -> Optional["EventLoopThread"]:
 
 
 def set_event_loop_thread(thread: Optional["EventLoopThread"]) -> None:
-    """Set the global event loop thread.
-    """
+    """Set the global event loop thread."""
     global _event_loop_thread
     _event_loop_thread = thread
 
@@ -56,6 +56,7 @@ def async_to_sync(async_fn: Callable[..., Awaitable[R]]) -> Callable[..., R]:
     """Wrap an async function to run it on the event loop thread and
     synchronously wait for its result on the calling thread.
     """
+
     @functools.wraps(async_fn)
     def wrapper(*args, **kwargs) -> R:
         event_loop_thread = get_event_loop_thread()
@@ -70,8 +71,7 @@ def async_to_sync(async_fn: Callable[..., Awaitable[R]]) -> Callable[..., R]:
 
 
 class EventLoopThread(threading.Thread):
-    """A thread that runs an asyncio event loop.
-    """
+    """A thread that runs an asyncio event loop."""
 
     interrupt_check_ival: float
     logger: logging.Logger
@@ -114,6 +114,37 @@ class EventLoopThread(threading.Thread):
             self.logger.info("Stopping event loop...")
             self.loop.call_soon_threadsafe(self.loop.stop)
 
+    def run_callback(self, callback: Callable[[], R]) -> R:
+        """Run a (sync) callback on the event loop and return the result."""
+        future = Future()
+
+        def call_and_set_result() -> None:
+            future.set_result(callback())
+
+        self.loop.call_soon_threadsafe(call_and_set_result)
+        return future.result()
+
+    def create_task(self, coro: Awaitable[R]) -> Tuple[asyncio.Task, Future]:
+        """Schedule the coroutine to run on the event loop
+
+        Also conveniently creates as concurrent.future.Future that allows for
+        waiting on the task to finish.
+        """
+        future = Future()
+
+        def task_done_callback(fut: asyncio.Future) -> None:
+            try:
+                future.set_result(fut.result())
+            except BaseException as e:
+                future.set_exception(e)
+
+        def create_task() -> asyncio.Task:
+            task = self.loop.create_task(coro)
+            task.add_done_callback(task_done_callback)
+            return task
+
+        return self.run_callback(create_task), future
+
     def run_coroutine(self, coro: Awaitable[R]) -> R:
         """Runs the given coroutine on the event loop.
 
@@ -129,16 +160,21 @@ class EventLoopThread(threading.Thread):
         if not self.loop.is_running():
             raise RuntimeError("Event loop is not running.")
 
-        future = asyncio.run_coroutine_threadsafe(coro, self.loop)
-        while True:
-            try:
-                # Use a timeout to be able to catch asynchronously
-                # raised dramatiq exceptions (Interrupt).
-                return future.result(timeout=self.interrupt_check_ival)
-            except Interrupt:
-                # Asynchronously raised from another thread: cancel
-                # the future and reiterate to wait for possible
-                # cleanup actions.
-                self.loop.call_soon_threadsafe(future.cancel)
-            except concurrent.futures.TimeoutError:
-                continue
+        task, future = self.create_task(coro)
+        try:
+            while True:
+                try:
+                    # Use a timeout to be able to catch asynchronously
+                    # raised dramatiq exceptions (Interrupt).
+                    future.result(timeout=self.interrupt_check_ival)
+                except concurrent.futures.TimeoutError:
+                    continue
+                else:
+                    break
+        except Interrupt:
+            # Asynchronously raised from another thread: cancel
+            # the future and reiterate to wait for possible
+            # cleanup actions.
+            self.loop.call_soon_threadsafe(task.cancel)
+
+        return future.result()

--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -73,6 +73,13 @@ def test_event_loop_thread_run_coroutine_exception(started_thread: EventLoopThre
     assert e.traceback[-1].name == "raise_actual_error"
 
 
+@pytest.mark.skipif(
+    threading.current_platform not in threading.supported_platforms,
+    reason="Threading not supported on this platform.",
+)
+@pytest.mark.skipif(
+    threading.is_gevent_active(), reason="Thread exceptions not supported with gevent."
+)
 def test_event_loop_thread_run_coroutine_interrupted(started_thread: EventLoopThread):
     side_effect_target = {"cleanup": False}
 

--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -1,12 +1,15 @@
 import asyncio
 from threading import get_ident
 from unittest import mock
-import traceback
 from dramatiq import threading
 import pytest
-import concurrent.futures
 
-from dramatiq.asyncio import EventLoopThread, async_to_sync, get_event_loop_thread, set_event_loop_thread
+from dramatiq.asyncio import (
+    EventLoopThread,
+    async_to_sync,
+    get_event_loop_thread,
+    set_event_loop_thread,
+)
 from dramatiq.logging import get_logger
 from dramatiq.middleware.asyncio import AsyncIO
 
@@ -56,7 +59,7 @@ def test_event_loop_thread_run_coroutine(started_thread: EventLoopThread):
 def test_event_loop_thread_run_coroutine_exception(started_thread: EventLoopThread):
     async def raise_actual_error():
         raise TypeError("bla")
-    
+
     async def raise_error():
         await raise_actual_error()
 
@@ -82,7 +85,7 @@ def test_event_loop_thread_run_coroutine_interrupted(started_thread: EventLoopTh
             await asyncio.sleep(0.01)
             side_effect_target["cleanup"] = True
 
-    with pytest.raises(concurrent.futures.CancelledError) as e:
+    with pytest.raises(threading.Interrupt):
         started_thread.run_coroutine(sleep_interrupt(get_ident()))
 
     assert side_effect_target["cleanup"]

--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -86,7 +86,7 @@ def test_event_loop_thread_run_coroutine_interrupted(started_thread: EventLoopTh
             await asyncio.sleep(0.01)
             side_effect_target["cleanup"] = True
 
-    with pytest.raises(threading.Interrupt):
+    with pytest.raises(asyncio.CancelledError):
         started_thread.run_coroutine(sleep_interrupt(get_ident()))
 
     assert side_effect_target["cleanup"]

--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -86,7 +86,7 @@ def test_event_loop_thread_run_coroutine_interrupted(started_thread: EventLoopTh
             await asyncio.sleep(0.01)
             side_effect_target["cleanup"] = True
 
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(threading.Interrupt):
         started_thread.run_coroutine(sleep_interrupt(get_ident()))
 
     assert side_effect_target["cleanup"]

--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -1,12 +1,15 @@
 import asyncio
 from threading import get_ident
 from unittest import mock
-import traceback
 from dramatiq import threading
 import pytest
-import concurrent.futures
 
-from dramatiq.asyncio import EventLoopThread, async_to_sync, get_event_loop_thread, set_event_loop_thread
+from dramatiq.asyncio import (
+    EventLoopThread,
+    async_to_sync,
+    get_event_loop_thread,
+    set_event_loop_thread,
+)
 from dramatiq.logging import get_logger
 from dramatiq.middleware.asyncio import AsyncIO
 
@@ -56,7 +59,7 @@ def test_event_loop_thread_run_coroutine(started_thread: EventLoopThread):
 def test_event_loop_thread_run_coroutine_exception(started_thread: EventLoopThread):
     async def raise_actual_error():
         raise TypeError("bla")
-    
+
     async def raise_error():
         await raise_actual_error()
 
@@ -74,6 +77,7 @@ def test_event_loop_thread_run_coroutine_interrupted(started_thread: EventLoopTh
     side_effect_target = {"cleanup": False}
 
     async def sleep_interrupt(worker_thread_id: int):
+        await asyncio.sleep(0.01)
         threading.raise_thread_exception(worker_thread_id, threading.Interrupt)
         try:
             for _ in range(100):
@@ -82,7 +86,7 @@ def test_event_loop_thread_run_coroutine_interrupted(started_thread: EventLoopTh
             await asyncio.sleep(0.01)
             side_effect_target["cleanup"] = True
 
-    with pytest.raises(concurrent.futures.CancelledError) as e:
+    with pytest.raises(asyncio.CancelledError):
         started_thread.run_coroutine(sleep_interrupt(get_ident()))
 
     assert side_effect_target["cleanup"]


### PR DESCRIPTION
Following up #536 ; it seems that there is no cleanup happening when an asyncio actor is interrupted. It is often important to leave stuff in a consistent state (e.g. releasing a lock) when interrupting an actor.

This does not happen correctly as soon as there is an `await` in the `finally` block.

~I have no clue yet how to approach this issue.~

Redoing the `run_courotine_threadsafe` turned out to be quite cumbersome. So in the end I solved the issue by adding a "done" event and wrapping the coroutine in a `try .. finally`.