### PR TITLE
Mark message as failed when fail to process

### DIFF
--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -503,6 +503,7 @@ class _WorkerThread(Thread):
 
         except BaseException as e:
             message.stuff_exception(e)
+            message.fail()
 
             throws = message.options.get("throws") or (actor and actor.options.get("throws"))
             if isinstance(e, RateLimitExceeded):


### PR DESCRIPTION
Mark message as `failed` when actor raises an Exception.

On `self.consumers[message.queue_name].post_process_message(message)` the method `nack` will be called.

This change will enable refactor on `dramatiq_sqs` to skip message delete and redrive message to dlq. https://github.com/Bogdanp/dramatiq_sqs/issues/10#issuecomment-1502280022