### PR TITLE
Don't reload on watchdog 'opened' events

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,8 +13,16 @@ Added
 
 * Asyncio support.  (`#536`_, `@caspervdw`_)
 
+Changed
+^^^^^^^
+
+* Filesystem watcher no longer reloads dramatiq on file open events.
+  (`#552`_, `@seanpile`_)
+
 .. _#536: https://github.com/Bogdanp/dramatiq/pull/536
+.. _#552: https://github.com/Bogdanp/dramatiq/pull/552
 .. _@caspervdw: https://github.com/caspervdw
+.. _@caspervdw: https://github.com/seanpile
 
 
 `1.14.2`_ -- 2023-03-25

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ max-line-length = 120
 max-complexity = 20
 max-line-length = 120
 select = C,E,F,W,B,B9,Q0
-ignore = E127,E402,E501,F403,F811,W504,B010,B020,B905
+ignore = E127,E402,E501,F403,F811,W504,B010,B020,B905,B908
 
 inline-quotes = double
 multiline-quotes = double

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -75,4 +75,3 @@ def test_cli_can_watch_for_source_code_changes(start_cli, extra_args):
         timestamp_3 = int(f.read())
 
     assert last_loaded_at == timestamp_3
-

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -62,3 +62,17 @@ def test_cli_can_watch_for_source_code_changes(start_cli, extra_args):
 
     # And the second time to be at least a second apart from the first
     assert timestamp_2 - timestamp_1 >= 1000
+
+    # When I open a watched file, this should not trigger a reload
+    last_loaded_at = timestamp_2
+    with (Path("tests") / "test_watch.py").open("r"):
+        time.sleep(5)
+        write_loaded_at.send(filename)
+        broker.join(write_loaded_at.queue_name)
+
+    # Then I expect another timestamp to have been written to the file
+    with open(filename, "r") as f:
+        timestamp_3 = int(f.read())
+
+    assert last_loaded_at == timestamp_3
+


### PR DESCRIPTION
As of watchdog >= 2.3, file open events on certain platforms are causing an 'opened' event to be delivered.  We should not be restarting the server on these changes, as they can be spammy and disruptive.

I was able to confirm the behaviour by running the tests within a debian-like environment (python slim bullseye); without the fix, the `tests/test_watch.py` would fail for the first test case (the evented observer)

For more context, see discussions here:

- https://github.com/gorakhargosh/watchdog/issues/949
- https://github.com/pallets/werkzeug/pull/2604/files