### PR TITLE
fix: detect the missing of rabbitmq queue and redeclare it.

### DIFF
--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -345,6 +345,12 @@ class RabbitmqBroker(Broker):
                 # next caller/attempt may initiate new ones of each.
                 del self.connection
 
+                # If the queue disappears, remove it from the known set
+                # so that it can be redeclared on retry or the next time
+                # a message is enqueued.
+                if getattr(e, "reply_code", None) == 404:
+                    self.queues.remove(q_name(queue_name))
+
                 attempts += 1
                 if attempts > MAX_ENQUEUE_ATTEMPTS:
                     raise ConnectionClosed(e) from None

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -1,6 +1,4 @@
 import os
-import random
-import string
 import time
 from threading import Event
 from unittest.mock import Mock, patch


### PR DESCRIPTION
The declared rabbitmq queue will be missing sometime, such as deletion by mistake or rabbitmq server failure. So I add some logic to make sure the missing queue to be declared again, as the recent implementation won't auto re-declare the missing queue.

There are two situation to re-declare the missing queue:

- Declare the queue every time when the consumer start.
- Redeclare the queue when queue is found to be missing during enqueue.