### PR TITLE
Use backend from group/pipeline broker in get_result(s)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,3 +59,4 @@ of those changes to CLEARTYPE SRL.
 | [@dancardin](https://github.com/dancardin)             | Dan Cardin             |
 | [@caspervdw](https://github.com/caspervdw)             | Casper van der Wel     |
 | [@jenstroeger](https://github.com/jenstroeger/)        | Jens Troeger           |
+| [@DiegoPomares](https://github.com/DiegoPomares/)      | Diego Pomares          |

--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -20,6 +20,7 @@ from typing import Optional, cast
 from .errors import ActorNotFound
 from .logging import get_logger
 from .middleware import MiddlewareError, default_middleware
+from .results import Results
 
 #: The global broker instance.
 global_broker: Optional["Broker"] = None
@@ -255,6 +256,21 @@ class Broker:
           on this Broker.
         """
         return self.delay_queues.copy()
+
+    def get_results_backend(self):
+        """Get the backend of the Results middleware.
+
+        Raises:
+          RuntimeError: If the broker doesn't have a results backend.
+
+        Returns:
+          ResultBackend: The backend.
+        """
+        for middleware in self.middleware:
+            if isinstance(middleware, Results):
+                return middleware.backend
+        else:
+            raise RuntimeError("The broker doesn't have a results backend.")
 
     def flush(self, queue_name):  # pragma: no cover
         """Drop all the messages from a queue.

--- a/dramatiq/composition.py
+++ b/dramatiq/composition.py
@@ -141,7 +141,13 @@ class pipeline:
         Returns:
           object: The result.
         """
-        return self.messages[-1].get_result(block=block, timeout=timeout)
+        last_message = self.messages[-1]
+
+        if isinstance(last_message, (group, pipeline)):
+            return last_message.get_result(block=block, timeout=timeout)
+
+        backend = self.broker.get_results_backend()
+        return last_message.get_result(backend=backend, block=block, timeout=timeout)
 
     def get_results(self, *, block=False, timeout=None):
         """Get the results of each job in the pipeline.
@@ -166,8 +172,11 @@ class pipeline:
             if deadline:
                 timeout = max(0, int((deadline - time.monotonic()) * 1000))
 
-            yield message.get_result(block=block, timeout=timeout)
+            if isinstance(message, (group, pipeline)):
+                yield message.get_result(block=block, timeout=timeout)
 
+            backend = self.broker.get_results_backend()
+            yield message.get_result(backend=backend, block=block, timeout=timeout)
 
 class group:
     """Run a group of actors in parallel.
@@ -330,8 +339,11 @@ class group:
 
             if isinstance(child, group):
                 yield list(child.get_results(block=block, timeout=timeout))
-            else:
+            elif isinstance(child, pipeline):
                 yield child.get_result(block=block, timeout=timeout)
+            else:
+                backend = self.broker.get_results_backend()
+                yield child.get_result(backend=backend, block=block, timeout=timeout)
 
     def wait(self, *, timeout=None):
         """Block until all the jobs in the group have finished or

--- a/dramatiq/composition.py
+++ b/dramatiq/composition.py
@@ -178,6 +178,7 @@ class pipeline:
             backend = self.broker.get_results_backend()
             yield message.get_result(backend=backend, block=block, timeout=timeout)
 
+
 class group:
     """Run a group of actors in parallel.
 

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -163,12 +163,7 @@ class Message(Generic[R]):
         """
         if backend is None:
             broker = get_broker()
-            for middleware in broker.middleware:
-                if isinstance(middleware, Results):
-                    backend = middleware.backend
-                    break
-            else:
-                raise RuntimeError("The default broker doesn't have a results backend.")
+            backend = broker.get_results_backend()
 
         return backend.get_result(self, block=block, timeout=timeout)
 

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -24,7 +24,7 @@ from .broker import get_broker
 from .composition import pipeline
 from .encoder import Encoder, JSONEncoder
 from .errors import DecodeError
-from .results import ResultBackend, Results
+from .results import ResultBackend
 
 #: The global encoder instance.
 global_encoder: Encoder = JSONEncoder()


### PR DESCRIPTION
These are the proposed changes to address the issue described in: https://github.com/Bogdanp/dramatiq/issues/564

The issue is that the groups and pipelines look for the backend of the default/global broker when getting results, regardless of the broker they were declared with.