### PR TITLE
doc: mention return value for group.run() methods

### DIFF
--- a/dramatiq/composition.py
+++ b/dramatiq/composition.py
@@ -251,6 +251,9 @@ class group:
         Parameters:
           delay(int): The minimum amount of time, in milliseconds,
             each message in the group should be delayed by.
+
+        Returns:
+          group: This same group.
         """
         if self.completion_callbacks:
             from .middleware.group_callbacks import GROUP_CALLBACK_BARRIER_TTL, GroupCallbacks


### PR DESCRIPTION
I noticed that the return value isn’t documented in the API docs [here](https://dramatiq.io/reference.html#dramatiq.group.run) which makes reading [this example](https://dramatiq.io/cookbook.html#groups)
```python
g = group([
    frobnicate.message(1, 2),
    frobnicate.message(2, 3),
    frobnicate.message(3, 4),
]).run()
```
questionable if `run()` wouldn’t return anything.

And while I’m poking some more through the documentation I noticed a few things:

- This line https://github.com/Bogdanp/dramatiq/blob/76578a6ea5017f5a0680279692eee357d7b7f229/docs/source/reference.rst?plain=1#L81 I think could use a `:members:` to document the `get_current_message()` class method which isn’t currently documented [here](https://dramatiq.io/reference.html#dramatiq.middleware.CurrentMessage).
- This line https://github.com/Bogdanp/dramatiq/blob/76578a6ea5017f5a0680279692eee357d7b7f229/docs/source/cookbook.rst?plain=1#L343 I think the `Retries middleware` could be a link to the `Retries` class.
- I also noticed that [composition](https://dramatiq.io/cookbook.html#groups) mentions waiting on the `group` or `pipeline` but that seems to require the result backend; that dependency should probably be documented?

I can add these minor docs changes to this PR, if you’d like.

<hr>

Furthermore, while `group` and `pipeline` have a `wait()` method that builds on `get_results()` the [Message](https://dramatiq.io/reference.html#dramatiq.Message) doesn’t have a `wait()` — which would be useful?