### PR TITLE
Support redis-py 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extra_dependencies = {
     ],
 
     "redis": [
-        "redis>=2.0,<5.0",
+        "redis>=2.0,<6.0",
     ],
 
     "watch": [


### PR DESCRIPTION
This PR enables support for redis-py 5.0.0.

https://github.com/redis/redis-py/releases