### PR TITLE
Add support for timedelta as actor delay

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,3 +59,4 @@ of those changes to CLEARTYPE SRL.
 | [@dancardin](https://github.com/dancardin)             | Dan Cardin             |
 | [@caspervdw](https://github.com/caspervdw)             | Casper van der Wel     |
 | [@jenstroeger](https://github.com/jenstroeger/)        | Jens Troeger           |
+| [@h3nnn4n](https://github.com/h3nnn4n/)                | Renan S Silva          |

--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 import time
+from datetime import timedelta
 from inspect import iscoroutinefunction
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Generic, Optional, TypeVar, Union, overload
 
@@ -141,7 +142,7 @@ class Actor(Generic[P, R]):
         self, *,
         args: tuple = (),
         kwargs: Optional[Dict[str, Any]] = None,
-        delay: Optional[int] = None,
+        delay: Optional[timedelta | int] = None,
         **options,
     ) -> Message[R]:
         """Asynchronously send a message to this actor, along with an
@@ -152,13 +153,16 @@ class Actor(Generic[P, R]):
           args(tuple): Positional arguments that are passed to the actor.
           kwargs(dict): Keyword arguments that are passed to the actor.
           delay(int): The minimum amount of time, in milliseconds, the
-            message should be delayed by.
+            message should be delayed by. Also accepts a timedelta.
           **options: Arbitrary options that are passed to the
             broker and any registered middleware.
 
         Returns:
           Message: The enqueued message.
         """
+        if isinstance(delay, timedelta):
+            delay = delay.total_seconds() * 1000
+
         message = self.message_with_options(args=args, kwargs=kwargs, **options)
         return self.broker.enqueue(message, delay=delay)
 

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -1,4 +1,5 @@
 import time
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -258,8 +259,8 @@ def test_actors_can_delay_messages_independent_of_each_other(stub_broker, stub_w
     # If I send it a delayed message
     append.send_with_options(args=(1,), delay=1500)
 
-    # And then another delayed message with a smaller delay
-    append.send_with_options(args=(2,), delay=1000)
+    # And then another delayed message with a smaller delay and using a timedelta
+    append.send_with_options(args=(2,), delay=timedelta(seconds=1))
 
     # Then join on the queue
     stub_broker.join(append.queue_name)


### PR DESCRIPTION
This implements https://github.com/Bogdanp/dramatiq/issues/522 as suggested by @dragonpaw

Support for using `timedelta` for the actor delay was added at the public interface. Alternatively it could have been implemented by switching to timedelta internally and converting to int / float when interfacing with external libraries. This would improve type safety in dramatiq, but it is a more intrusive change.

Based on feedback from this PR I can open a followup to support `timedelta` for timeout args as well.