### PR TITLE
doc: add members documentation to Result middleware, and Results and Rate Limiters backends

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -123,11 +123,13 @@ Middleware
 ^^^^^^^^^^
 
 .. autoclass:: dramatiq.results.Results
+   :members:
 
 Backends
 ^^^^^^^^
 
 .. autoclass:: dramatiq.results.ResultBackend
+   :members:
 .. autoclass:: dramatiq.results.backends.MemcachedBackend
 .. autoclass:: dramatiq.results.backends.RedisBackend
 .. autoclass:: dramatiq.results.backends.StubBackend
@@ -146,6 +148,7 @@ Backends
 Rate limiter backends are used to store metadata about rate limits.
 
 .. autoclass:: dramatiq.rate_limits.RateLimiterBackend
+   :members:
 .. autoclass:: dramatiq.rate_limits.backends.MemcachedBackend
 .. autoclass:: dramatiq.rate_limits.backends.RedisBackend
 .. autoclass:: dramatiq.rate_limits.backends.StubBackend


### PR DESCRIPTION
…like they are for other ABCs and e.g. the Rate Limiter itself:

https://github.com/Bogdanp/dramatiq/blob/8e0ced79ee55bd8062063d6274c70bcbf1ce362a/docs/source/reference.rst?plain=1#L154-L158

Probably wouldn’t help much to document the members of the subclasses 🤔