### PR TITLE
redis: add support for broker priority

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -76,6 +76,49 @@ failover if the currently connected node fails.
 .. _high availability cluster: https://www.rabbitmq.com/ha.html
 .. _connection parameters: https://pika.readthedocs.io/en/0.12.0/modules/parameters.html
 
+Broker Priority Queues
+^^^^^^^^^^^^^^^^^^^^^^^
+Dramatiq supports priority queues on RabbitMQ and Redis.
+To configure the broker to work with priority queues, you should set the ``max_priority`` parameter of the broker.
+To enqueue a message with a priority, you should set the ``broker_priority`` parameter of the |Message|'s options.
+
+
+.. code-block:: python
+
+   import dramatiq
+   from dramatiq.brokers.rabbitmq import RabbitmqBroker
+
+   # Using max_priority parameter:
+
+   rabbitmq_broker = RabbitmqBroker(url="amqp://guest:guest@127.0.0.1:5672", max_priority=10)
+
+    # Define an actor with priority:
+    @dramatiq.actor(broker=rabbitmq_broker)
+    def operation(priority):
+        print(priority)
+
+   # Enqueue a message with priority (lower number means higher priority):
+    operation.send_with_options(args=(3,), options={"broker_priority": 3})
+    operation.send_with_options(args=(2,), options={"broker_priority": 2})
+    operation.send_with_options(args=(1,), options={"broker_priority": 1})
+
+
+RabbitMQ
+~~~~~~~~
+Dramatiq supports RabbitMQ's `priority queues`_ feature.
+To use it, you should set the ``max_priority`` parameter of the |RabbitmqBroker| to a value
+between 0 and 255 (10 is the recommended values).
+
+.. `priority queues`_: https://www.rabbitmq.com/priority.html
+
+
+Redis
+~~~~~
+Dramatiq take similar approach as celery to implement priority queues on Redis.
+To use it, you should set the ``max_priority`` parameter of the |RedisBroker| to a value up to 10.
+The broker will created multiple queues for each priority level defined by ``priority_steps``, (default is 4 steps).
+The consumer will consume messages from the highest priority queue first.
+This method isn't as reliable as RabbitMQ's, for example, large number of messages ending up in the same queue.
 
 Other brokers
 ^^^^^^^^^^^^^

--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -299,6 +299,16 @@ class Broker:
         """
         raise NotImplementedError()
 
+    def get_queue_size(self, queue_name: str):
+        """
+        Get the number of messages in a queue.  This method is only meant to be used in unit and integration tests.
+        Parameters:
+            queue_name(str): The queue whose message counts to get.
+
+        Returns: The number of messages in the queue, including the delay queue
+        """
+        raise NotImplementedError()
+
 
 class Consumer:
     """Consumers iterate over messages on a queue.

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -431,6 +431,16 @@ class RabbitmqBroker(Broker):
 
             self.connection.sleep(idle_time / 1000)
 
+    def get_queue_size(self, queue_name: str):
+        """
+        Get the number of messages in a queue.  This method is only meant to be used in unit and integration tests.
+        Parameters:
+            queue_name(str): The queue whose message counts to get.
+
+        Returns: The number of messages in the queue, including the delay queue
+        """
+        return sum(self.get_queue_message_counts(queue_name)[:-1])
+
 
 def URLRabbitmqBroker(url, *, middleware=None):
     """Alias for the RabbitMQ broker that takes a connection URL as a

--- a/dramatiq/brokers/redis/dispatch.lua
+++ b/dramatiq/brokers/redis/dispatch.lua
@@ -68,6 +68,9 @@ local queue_acks = acks .. "." .. queue_name
 local queue_full_name = namespace .. ":" .. queue_name
 local queue_messages = queue_full_name .. ".msgs"
 local xqueue_full_name = namespace .. ":" .. queue_canonical_name .. ".XQ"
+if string.sub(queue_canonical_name, -4, -2) == ".PR" then
+    xqueue_full_name = namespace .. ":" .. string.sub(queue_canonical_name, 1, -5) .. ".XQ"
+end
 local xqueue_messages = xqueue_full_name .. ".msgs"
 
 -- Command-specific arguments.

--- a/dramatiq/brokers/stub.py
+++ b/dramatiq/brokers/stub.py
@@ -176,6 +176,17 @@ class StubBroker(Broker):
 
                 return
 
+    def get_queue_size(self, queue_name):
+        """Returns the number of messages in a queue.
+
+        Parameters:
+          queue_name(str): The queue to inspect.
+
+        Returns:
+          int: The number of messages in the queue.
+        """
+        return self.queues[queue_name].qsize() + self.queues[dq_name(queue_name)].qsize()
+
 
 class _StubConsumer(Consumer):
     def __init__(self, queue, dead_letters, timeout):


### PR DESCRIPTION
Create different queues for priority steps and consuming them in that order.
I took a similar approach as celery's implementation of priority queues in redis.