### PR TITLE
Add build support for python3.12, drop python3.7

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - run: pip install tox
       - run: tox -e lint
 
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         concurrency: ["cpython", "gevent"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: python -m pip install build

--- a/setup.py
+++ b/setup.py
@@ -120,11 +120,11 @@ setup(
     entry_points={"console_scripts": ["dramatiq = dramatiq.__main__:main"]},
     scripts=["bin/dramatiq-gevent"],
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: System :: Distributed Computing",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-  py{37,38,39,310,311}-cpython
-  py{37,38,39,310,311}-cpython-gevent
+  py{38,39,310,311,312}-cpython
+  py{38,39,310,311,312}-cpython-gevent
   docs
   lint
 
@@ -13,7 +13,7 @@ commands=
 passenv=
   TRAVIS
 
-[testenv:py{37,38,39,310,311}-cpython-gevent]
+[testenv:py{38,39,310,311,312}-cpython-gevent]
 extras=
   dev
 commands=


### PR DESCRIPTION
Python3.12 has been released and python3.7 has been past end-of-life since 2023-06-27.
This change adds build support for python3.12 and drops build support for python3.7. 