### PR TITLE
Remove results message key dependency from actor and queue

### DIFF
--- a/dramatiq/results/backend.py
+++ b/dramatiq/results/backend.py
@@ -143,10 +143,8 @@ class ResultBackend:
         Returns:
           str
         """
-        message_key = "%(namespace)s:%(queue_name)s:%(actor_name)s:%(message_id)s" % {
+        message_key = "%(namespace)s:%(message_id)s" % {
             "namespace": self.namespace,
-            "queue_name": q_name(message.queue_name),
-            "actor_name": message.actor_name,
             "message_id": message.message_id,
         }
         return hashlib.md5(message_key.encode("utf-8")).hexdigest()


### PR DESCRIPTION
The idea here is to allow the possibility to get a result only based on a `message_id` and `namespace` like the following example:

**app.py**
```
results = RedisBackend(host="localhost", namespace="my-results")
```

**endpoint.py**: fastapi endpoint to collect result of a long task
```
from .app import results

@router.get("/{message_id}")
async def get(message_id: str):
    message = Message(
        queue_name="",
        actor_name="",
        message_id=message_id,
        args=(),
        kwargs={},
        options={},
    )

    data = json.loads(results.get_result(message))
    
    return data
```

I believe removing `actor` and `queue` from the generation of message key will not affect in any way the system.