### PR TITLE
Improve handling of newlines in log messages

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,3 +63,4 @@ of those changes to CLEARTYPE SRL.
 | [@DiegoPomares](https://github.com/DiegoPomares/)      | Diego Pomares          |
 | [@pahrohfit](https://github.com/pahrohfit/)            | Robert Dailey          |
 | [@nhairs](https://github.com/nhairs)                   | Nicholas Hairs         |
+| [@5tefan](https://github.com/5tefan/)                  | Stefan Codrescu        |

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,10 +13,14 @@ Fixed
 
 * The ``CurrentMessage`` middleware now works under AsyncIO. (`#586`_,
   `#593`_, `@pahrohfit`_)
+* Improved logging behavior under different buffer modes. (`#596`_,
+  `@5tefan`_)
 
 .. _#586: https://github.com/Bogdanp/dramatiq/issues/586
 .. _#593: https://github.com/Bogdanp/dramatiq/pull/593
+.. _#596: https://github.com/Bogdanp/dramatiq/pull/596
 .. _@pahrohfit: https://github.com/pahrohfit
+.. _@5tefan: https://github.com/5tefan
 
 Added
 ^^^^^

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -338,10 +338,6 @@ def watch_logs(log_filename, pipes, stop):
                 for event in events:
                     try:
                         while event.poll():
-                            # StreamHandler writes newlines into the pipe separately
-                            # from the actual log entry; to avoid back-to-back newlines
-                            # in the events pipe (causing multiple entries on a single
-                            # line), discard newline-only data from the pipe
                             try:
                                 data = event.recv_bytes()
                             except EOFError:
@@ -349,9 +345,6 @@ def watch_logs(log_filename, pipes, stop):
                                 raise
 
                             data = data.decode("utf-8", errors="replace")
-                            if not data.rstrip("\n"):
-                                continue
-
                             log_file.write(data)
                             log_file.flush()
                     except BrokenPipeError:

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -348,11 +348,11 @@ def watch_logs(log_filename, pipes, stop):
                                 event.close()
                                 raise
 
-                            data = data.decode("utf-8", errors="replace").rstrip("\n")
-                            if not data:
+                            data = data.decode("utf-8", errors="replace")
+                            if not data.rstrip("\n"):
                                 continue
 
-                            log_file.write(data + "\n")
+                            log_file.write(data)
                             log_file.flush()
                     except BrokenPipeError:
                         event.close()


### PR DESCRIPTION
(Apologies for not starting a discussion as requested in contributing guidelines... let's have the discussion here and reject this PR if it doesn't align with your vision.)

## Summary

Improves the newline handling in log forwarding from workers so that it does not always introduce newlines.

### Problem

Due to some unknown change in our setup, we started seeing log messages from workers split into multiple lines:

<img width="680" alt="image" src="https://github.com/Bogdanp/dramatiq/assets/5855806/37ef5de6-7109-4b36-a830-5eb5b0f711b2">

Perhaps we are flushing log message more frequently than expected by dramatiq... and the flushes are not aligned with newlines. 

### Solution

After some digging, we found that the newlines are inserted by dramatiq here:

https://github.com/Bogdanp/dramatiq/blob/a30b7878c5f7570864b1e056580faecbf2abdad2/dramatiq/cli.py#L322-L338

 This code _always_ adds a newline, even if the `rstrip` did not strip one out.

Given the comment above this code section explaining the goal:

> discard newline-only data from the pipe

I believe this revision accomplishes this better by only using `rstrip` for the continue condition (to not pass blank lines),but otherwise passing the log without modification.