### PR TITLE
Prometheus middleware improvements

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -64,3 +64,4 @@ of those changes to CLEARTYPE SRL.
 | [@pahrohfit](https://github.com/pahrohfit/)            | Robert Dailey          |
 | [@nhairs](https://github.com/nhairs)                   | Nicholas Hairs         |
 | [@5tefan](https://github.com/5tefan/)                  | Stefan Codrescu        |
+| [@stat1c-void](https://github.com/stat1c-void)         | Sergei                 |

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -339,16 +339,23 @@ Gotchas with Prometheus
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The Prometheus client for Python is a bit finicky when it comes to
-exporting metrics from a multi-process configuration.  If your own app
-uses Prometheus, then you should export ``prometheus_multiproc_dir``
-and ``dramatiq_prom_db`` environment variables -- both pointing to an
-existing folder -- and remove any files in that folder before running
-Dramatiq.  For example::
+exporting metrics from a multi-process configuration.
+
+By default, Dramatiq manages ``PROMETHEUS_MULTIPROC_DIR`` environment
+variable, making sure the directory is unique per top-level Dramatiq
+process, and cleans it up during a graceful shutdown.
+
+But if your own app uses Prometheus and incorporates Dramatiq, then
+you should export ``PROMETHEUS_MULTIPROC_DIR`` and ``DRAMATIQ_PROM_DB``
+environment variables, both pointing to an existing directory. In this
+case, Dramatiq does not manage the directory, so it is your
+responsibility to do so -- e.g. to remove any files there before
+running Dramatiq. For example::
 
   mkdir -p /tmp/dramatiq-prometheus \
     && rm -r /tmp/dramatiq-prometheus/* \
-    && env prometheus_multiproc_dir=/tmp/dramatiq-prometheus \
-           dramatiq_prom_db=/tmp/dramatiq-prometheus \
+    && env PROMETHEUS_MULTIPROC_DIR=/tmp/dramatiq-prometheus \
+           DRAMATIQ_PROM_DB=/tmp/dramatiq-prometheus \
            dramatiq app
 
 If you don't do this, then metrics will likely fail to export properly.

--- a/dramatiq/middleware/prometheus.py
+++ b/dramatiq/middleware/prometheus.py
@@ -117,6 +117,7 @@ class Prometheus(Middleware):
             "The number of delayed messages in memory.",
             ["queue_name", "actor_name"],
             registry=registry,
+            multiprocess_mode="livesum",
         )
         self.message_durations = prom.Histogram(
             "dramatiq_message_duration_milliseconds",

--- a/tests/middleware/test_prometheus.py
+++ b/tests/middleware/test_prometheus.py
@@ -1,19 +1,66 @@
+import multiprocessing
+import os
+import tempfile
 import time
 import urllib.request as request
 from threading import Thread
 
-from dramatiq.middleware.prometheus import _run_exposition_server
+import pytest
+
+from dramatiq.middleware.prometheus import _prom_db_path, _run_exposition_server
 
 
-def test_prometheus_middleware_exposes_metrics():
-    # Given an instance of the exposition server
+def test_prometheus_middleware_exposes_metrics(tmp_path, monkeypatch):
+    # Given Prometheus multi-proc DB dir set up
+    prom_db_path = tmp_path / "dramatiq-prometheus"
+    prom_db_path.mkdir()
+    monkeypatch.setenv("DRAMATIQ_PROM_DB", str(prom_db_path))
+
+    # And given an instance of the exposition server
     thread = Thread(target=_run_exposition_server, daemon=True)
     thread.start()
 
-    # When I give it time to boot up
-    time.sleep(1)
-
     # And I request metrics via HTTP
-    with request.urlopen("http://127.0.0.1:9191") as resp:
-        # Then the response should be successful
-        assert resp.getcode() == 200
+    # use 5 tries, with 1 second delay each
+    for try_num in range(5):
+        time.sleep(1)
+        try:
+            with request.urlopen("http://127.0.0.1:9191") as resp:
+                # Then the response should be successful
+                assert resp.getcode() == 200
+                break
+        except OSError:
+            if try_num >= 4:
+                raise
+
+
+def test_prometheus_db_path_override(monkeypatch):
+    # Given Prometheus DB path override through ENV var
+    monkeypatch.setenv("DRAMATIQ_PROM_DB", "/foo/bar")
+    # When requesting DB path
+    db_path, is_external = _prom_db_path()
+    # Then the path should be overridden and is_external flag set
+    assert db_path == "/foo/bar"
+    assert is_external is True
+
+
+@pytest.fixture
+def default_db_path():
+    return f"{tempfile.gettempdir()}/dramatiq-prometheus-{os.getpid()}"
+
+
+def test_prometheus_db_path_current_pid(default_db_path):
+    # When requesting DB path from a process without parents
+    db_path, is_external = _prom_db_path()
+    # Then DB path should use the current PID, and is_external flag not set
+    assert db_path == default_db_path
+    assert is_external is False
+
+
+def test_prometheus_db_path_parent_pid(default_db_path):
+    # When requesting DB path from within a subprocess
+    with multiprocessing.Pool(1) as pool:
+        db_path, is_external = pool.apply(_prom_db_path)
+    # Then DB path should still use the current PID, and is_external flag not set
+    assert db_path == default_db_path
+    assert is_external is False


### PR DESCRIPTION
A number of Prometheus middleware improvements:
* canonical queue names in metrics
* livesum for a gauge that was seemingly missing
* unique PROMETHEUS_MULTIPROC_DIR per top-level process by default
* made prometheus metrics test a bit more stable (several tries)

Have successfully run `pytest --benchmark-skip` on my local python 3.10.14.

Some details below.

### Canonical queue names

If queue names aren't canonical, then something like this happens to metrics:
```
dramatiq_delayed_messages_inprogress{..., pid="7", queue_name="costs"} -1
dramatiq_delayed_messages_inprogress{..., pid="7", queue_name="costs.DQ"} 1
dramatiq_delayed_messages_inprogress{..., pid="7", queue_name="costs"} -4
dramatiq_delayed_messages_inprogress{..., pid="7", queue_name="costs.DQ"} 4
dramatiq_delayed_messages_inprogress{..., pid="7", queue_name="default.DQ"} 2
dramatiq_delayed_messages_inprogress{..., pid="6", queue_name="default"} -1
dramatiq_delayed_messages_inprogress{..., pid="6", queue_name="default.DQ"} 2
```

### Unique PROMETHEUS_MULTIPROC_DIR

Previously, Prometheus mutli-proc exporting would interfere between multiple Dramatiq instances on the same machine (because the prom DB path would be the same across different instances). Actually, would interfere even across restarts of the same Dramatiq instance (and even in containerized environments, when containers are just restarted, and not recreated).

In containerized env, top-level PID value is likely to be the same across runs, but with auto-cleanup it can be managed.

### Metrics test

Noticed that `test_prometheus_middleware_exposes_metrics` was sometimes failing due to timings - metrics endpoint wasn't ready in 1 second. Should be a bit more stable now.