### PR TITLE
Updated Retries middleware

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -64,3 +64,4 @@ of those changes to CLEARTYPE SRL.
 | [@pahrohfit](https://github.com/pahrohfit/)            | Robert Dailey          |
 | [@nhairs](https://github.com/nhairs)                   | Nicholas Hairs         |
 | [@5tefan](https://github.com/5tefan/)                  | Stefan Codrescu        |
+| [@kuba-lilz](https://github.com/kuba-lilz/)            | Jakub Kolodziejczyk    |

--- a/dramatiq/middleware/retries.py
+++ b/dramatiq/middleware/retries.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import time
 import traceback
 
 from ..common import compute_backoff
@@ -114,3 +115,9 @@ class Retries(Middleware):
 
         self.logger.info("Retrying message %r in %d milliseconds.", message.message_id, delay)
         broker.enqueue(message, delay=delay)
+
+    def before_enqueue(self, broker, message, delay):
+
+        # If message will be retried, record in its options time at which it is requeued
+        if "retries" in message.options:
+            message.options["requeue_timestamp"] = int(time.time() * 1000)


### PR DESCRIPTION
For motivation see discussion at 
https://groups.io/g/dramatiq-users/topic/how_to_check_how_long_message/106519634

Retries middleware now records requeue_timestamp on message options in `before_enqueue` function if message failed execution.

Hoped the implementation and tests are up to required standards, if not, let me know what needs to be changed.