### PR TITLE
Add callback for retry exhaustion

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,3 +65,4 @@ of those changes to CLEARTYPE SRL.
 | [@nhairs](https://github.com/nhairs)                   | Nicholas Hairs         |
 | [@5tefan](https://github.com/5tefan/)                  | Stefan Codrescu        |
 | [@kuba-lilz](https://github.com/kuba-lilz/)            | Jakub Kolodziejczyk    |
+| [@dbowring](https://github.com/dbowring/)              | Daniel Bowring         |

--- a/tests/middleware/test_retries.py
+++ b/tests/middleware/test_retries.py
@@ -352,3 +352,80 @@ def test_message_contains_requeue_time_after_retry(stub_broker, stub_worker):
 
     # And that all requeue timestamps are larger than message timestamp
     assert all(requeue_time > message.message_timestamp for requeue_time in requeue_timestamps)
+
+
+def test_on_retry_exhausted_is_sent(stub_broker, stub_worker):
+    attempted_at = []
+    called_at = []
+    max_retries = 2
+
+    @dramatiq.actor
+    def handle_retries_exhausted(message_data, retry_info):
+        called_at.append(time.monotonic())
+
+    @dramatiq.actor(max_retries=max_retries, on_retry_exhausted=handle_retries_exhausted.actor_name)
+    def do_work():
+        attempted_at.append(time.monotonic())
+        # Always request a retry
+        raise Retry(delay=1)
+
+    do_work.send()
+
+    stub_broker.join(do_work.queue_name)
+    stub_broker.join(handle_retries_exhausted.queue_name)
+    stub_worker.join()
+
+    # We should have the initial attempt + max_retries
+    assert len(attempted_at) == max_retries + 1
+    # And the exhausted handler should have been called.
+    assert len(called_at) == 1
+
+def test_on_retry_exhausted_is_not_sent_for_success(stub_broker, stub_worker):
+    attempted_at = []
+    called_at = []
+    max_retries = 2
+
+    @dramatiq.actor
+    def handle_retries_exhausted(message_data, retry_info):
+        called_at.append(time.monotonic())
+
+    @dramatiq.actor(max_retries=max_retries, on_retry_exhausted=handle_retries_exhausted.actor_name)
+    def do_work():
+        attempted_at.append(time.monotonic())
+
+    do_work.send()
+
+    stub_broker.join(do_work.queue_name)
+    stub_broker.join(handle_retries_exhausted.queue_name)
+    stub_worker.join()
+
+    # No retry should be required
+    assert len(attempted_at) == 1
+    # And the exhausted callback should have never been called
+    assert len(called_at) == 0
+
+def test_on_retry_exhausted_is_not_sent_for_eventual_success(stub_broker, stub_worker):
+    attempted_at = []
+    called_at = []
+    max_retries = 2
+
+    @dramatiq.actor
+    def handle_retries_exhausted(message_data, retry_info):
+        called_at.append(time.monotonic())
+
+    @dramatiq.actor(max_retries=max_retries, on_retry_exhausted=handle_retries_exhausted.actor_name)
+    def do_work():
+        attempted_at.append(time.monotonic())
+        if len(attempted_at) < 2:
+            raise Retry(delay=1)
+
+    do_work.send()
+
+    stub_broker.join(do_work.queue_name)
+    stub_broker.join(handle_retries_exhausted.queue_name)
+    stub_worker.join()
+
+    # The first retry should have succeeded
+    assert len(attempted_at) == 2
+    # So the exhausted callback should have never been called
+    assert len(called_at) == 0


### PR DESCRIPTION
E.g.,

```python
@dramatiq.actor
def on_abandon_flaky_work(message_data, retry_info):
    logger.info("Too flaky, will not retry", message_data=message_data, retry_info=retry_info)

@dramatiq.actor(max_retries=5, on_retry_exhausted=on_abandon_flaky_work.actor_name)
def my_flaky_actor(*args, **kwargs):
    do_flaky_work(*args, **kwargs)

```