### PR TITLE
Catch an anticipated DeprecationWarning

### DIFF
--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -19,7 +19,8 @@ def test_urlrabbitmq_creates_instances_of_rabbitmq_broker():
     url = "amqp://%s:%s@127.0.0.1:5672" % (RABBITMQ_USERNAME, RABBITMQ_PASSWORD)
 
     # When I pass that to URLRabbitmqBroker
-    broker = URLRabbitmqBroker(url)
+    with pytest.warns(DeprecationWarning):
+        broker = URLRabbitmqBroker(url)
 
     # Then I should get back a RabbitmqBroker
     assert isinstance(broker, RabbitmqBroker)


### PR DESCRIPTION
I found this while attempting to run the test suite locally with warnings turned on.

```
tests/test_rabbitmq.py:22:
DeprecationWarning: Use RabbitmqBroker with the 'url' parameter instead of URLRabbitmqBroker.
```

As this is a known and expected warning, this PR ensures the test suite catches the `DeprecationWarning`.