### PR TITLE
Close subprocess STDOUT pipes in the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,8 @@ def start_cli():
     if proc is not None:
         proc.terminate()
         proc.wait()
+        if proc.stdout is not None:
+            proc.stdout.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
Spotted this while attempting to run the test suite locally with warnings enabled.

```
tests/test_cli.py::test_cli_fails_to_start_given_an_invalid_broker_name
tests/test_cli.py::test_cli_fails_to_start_given_an_invalid_broker_instance
tests/test_cli.py::test_cli_fails_to_start_given_an_invalid_nested_broker_instance
  /home/kurt/dev/pr-dramatiq/.venv/lib/python3.12/site-packages/_pytest/runner.py:141:
ResourceWarning: unclosed file <_io.FileIO name=12 mode='rb' closefd=True>
```

The three tests listed are the only ones that read from STDOUT pipes; closing the pipe in the pytest fixture is the most reliable way to address this.