### PR TITLE
Close an asyncio event loop in the test suite

### DIFF
--- a/dramatiq/asyncio.py
+++ b/dramatiq/asyncio.py
@@ -112,6 +112,8 @@ class EventLoopThread(threading.Thread):
         if self.loop.is_running():
             self.logger.info("Stopping event loop...")
             self.loop.call_soon_threadsafe(self.loop.stop)
+            self.join()
+            self.loop.close()
 
     def run_coroutine(self, coro: Awaitable[R]) -> R:
         """Runs the given coroutine on the event loop.

--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -24,7 +24,6 @@ def started_thread():
     set_event_loop_thread(thread)
     yield thread
     thread.stop()
-    thread.join()
     set_event_loop_thread(None)
 
 


### PR DESCRIPTION
Noticed this warning while attempting to run the test suite with warnings enabled.

```
tests/middleware/test_asyncio.py::test_event_loop_thread_run_coroutine_interrupted
ResourceWarning: unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>
```

This PR makes calls to `.stop()` join the thread and then close the event loop, which resolves the warning above.