### PR TITLE
Prevent an uncaught exception warning in a test suite thread

### DIFF
--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -40,10 +40,14 @@ def test_event_loop_thread_start():
 
 def test_event_loop_thread_start_timeout():
     thread = EventLoopThread(logger=get_logger(__name__))
-    thread.loop = mock.Mock()
-    thread.loop.run_forever.side_effect = RuntimeError("fail")
-    with pytest.raises(RuntimeError):
+    loop_mock = mock.Mock()
+    # Store the original thread loop and replace it with a mock.
+    original_loop = thread.loop
+    thread.loop = loop_mock
+    with pytest.raises(RuntimeError, match="Event loop failed to start"):
         thread.start(timeout=0.1)
+    # Close the original event loop to prevent a ResourceWarning.
+    original_loop.close()
 
 
 def test_event_loop_thread_run_coroutine(started_thread: EventLoopThread):


### PR DESCRIPTION
Spotted this while attempting to run the test suite locally with warnings enabled:

```
tests/middleware/test_asyncio.py::test_event_loop_thread_start_timeout
  lib/python3.12/site-packages/_pytest/threadexception.py:77:
    PytestUnhandledThreadExceptionWarning: Exception in thread Thread-13
```

The easiest fix is to stop raising an exception in the mock. In addition, since `RuntimeError` may be raised in several ways, I added a `match` argument to the `pytest.raises()` context manager to identify which `RuntimeError` text is expected.

After avoiding that warning, a ResourceWarning popped up:

```
tests/middleware/test_asyncio.py::test_event_loop_thread_start_timeout
  lib/python3.12/asyncio/base_events.py:726:
    ResourceWarning: unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>
```

This happens because the underlying event loop (the one that is getting swapped out with a mock) is not getting closed.