### PR TITLE
Eliminate a test ordering dependency

### DIFF
--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -131,8 +131,11 @@ def test_async_to_sync(get_event_loop_thread_mocked):
     set_event_loop_thread(thread)
     fn = async_to_sync(async_fn)
     actual = fn(2)
-    thread.run_coroutine.assert_called_once()
-    assert actual is thread.run_coroutine()
+    try:
+        thread.run_coroutine.assert_called_once()
+        assert actual is thread.run_coroutine.return_value
+    finally:
+        set_event_loop_thread(None)
 
 
 def test_async_to_sync_with_actual_thread(started_thread):


### PR DESCRIPTION
If `test_async_to_sync` runs immediately before `test_async_to_sync_no_thread`, the "no thread" test will fail to raise `RuntimeError` because the module-level `_event_loop_thread` variable will still be set (although it will be a mock, not a real thread).

This was discovered while trying to eliminate a different warning that only pops up if all of the asyncio tests are run; if only a handful of tests were selected, the warning disappears.

I strongly recommend adding pytest-randomly to the test suite's Python dependencies to help shake out test suite interdependencies such as what was found here.