### PR TITLE
Fix additional test suite issues

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -3,9 +3,11 @@ import platform
 from contextlib import contextmanager
 
 import pika
+import pika.exceptions
 import pytest
 
 from dramatiq import Worker
+from dramatiq.brokers.rabbitmq import RabbitmqBroker
 from dramatiq.threading import is_gevent_active
 
 
@@ -33,3 +35,20 @@ skip_without_gevent = pytest.mark.skipif(not is_gevent_active(), reason="Behavio
 RABBITMQ_USERNAME = os.getenv("RABBITMQ_USERNAME", "guest")
 RABBITMQ_PASSWORD = os.getenv("RABBITMQ_PASSWORD", "guest")
 RABBITMQ_CREDENTIALS = pika.credentials.PlainCredentials(RABBITMQ_USERNAME, RABBITMQ_PASSWORD)
+
+
+def rabbit_mq_is_unreachable():
+    broker = RabbitmqBroker(
+        host="127.0.0.1",
+        max_priority=10,
+        credentials=RABBITMQ_CREDENTIALS,
+    )
+    try:
+        broker.connection
+    except pika.exceptions.AMQPConnectionError:
+        # RabbitMQ is unreachable
+        return True
+    return False
+
+
+skip_unless_rabbit_mq = pytest.mark.skipif(rabbit_mq_is_unreachable(), reason="RabbitMQ is unreachable")

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -11,7 +11,7 @@ from dramatiq import Message, Middleware, QueueJoinTimeout, Worker
 from dramatiq.brokers.rabbitmq import RabbitmqBroker, URLRabbitmqBroker, _IgnoreScaryLogs
 from dramatiq.common import current_millis
 
-from .common import RABBITMQ_CREDENTIALS, RABBITMQ_PASSWORD, RABBITMQ_USERNAME
+from .common import RABBITMQ_CREDENTIALS, RABBITMQ_PASSWORD, RABBITMQ_USERNAME, skip_unless_rabbit_mq
 
 
 def test_urlrabbitmq_creates_instances_of_rabbitmq_broker():
@@ -26,6 +26,7 @@ def test_urlrabbitmq_creates_instances_of_rabbitmq_broker():
     assert isinstance(broker, RabbitmqBroker)
 
 
+@skip_unless_rabbit_mq
 def test_rabbitmq_broker_can_be_passed_a_semicolon_separated_list_of_uris():
     # Given a string with a list of RabbitMQ connection URIs, including an invalid one
     # When I pass those URIs to RabbitMQ broker as a ;-separated string
@@ -36,6 +37,7 @@ def test_rabbitmq_broker_can_be_passed_a_semicolon_separated_list_of_uris():
     assert broker.connection
 
 
+@skip_unless_rabbit_mq
 def test_rabbitmq_broker_can_be_passed_a_list_of_uri_for_failover():
     # Given a string with a list of RabbitMQ connection URIs, including an invalid one
     # When I pass those URIs to RabbitMQ broker as a list
@@ -64,6 +66,7 @@ def test_rabbitmq_broker_raises_an_error_if_given_invalid_parameter_combinations
         RabbitmqBroker(host="127.0.0.1", parameters=[dict(host="127.0.0.1")])
 
 
+@skip_unless_rabbit_mq
 def test_rabbitmq_broker_can_be_passed_a_list_of_parameters_for_failover():
     # Given a list of pika connection parameters including an invalid one
     parameters = [
@@ -217,6 +220,7 @@ def test_rabbitmq_actors_can_have_retry_limits(rabbitmq_broker, rabbitmq_worker)
     assert xq_count == 1
 
 
+@skip_unless_rabbit_mq
 def test_rabbitmq_broker_connections_are_lazy():
     # When I create an RMQ broker
     broker = RabbitmqBroker(

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist=
-  py{38,39,310,311,312}-cpython
-  py{38,39,310,311,312}-cpython-gevent
+  py{38,39,310,311,312}{,-gevent}
   docs
   lint
 
@@ -13,7 +12,7 @@ commands=
 passenv=
   TRAVIS
 
-[testenv:py{38,39,310,311,312}-cpython-gevent]
+[testenv:py{38,39,310,311,312}-gevent]
 extras=
   dev
 commands=


### PR DESCRIPTION
This PR addresses two additional issues with the test suite:

* The "cpython" factor listed in the tox environments conflicts with the "py3<X>" factors.
* Some RabbitMQ tests are not guarded by the implicit "skip" provided by the `rabbitmq_broker` fixture.

These two issues are now addressed, and the test suite can be run more easily.

I recommend modifying CI to execute tox directly; this will more closely align local test suite execution and CI runs.