### PR TITLE
Enable all Python warnings in the test suite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,18 +5,22 @@ envlist=
   lint
 
 [testenv]
+setenv =
+    PYTHONTRACEMALLOC=1
 extras=
   dev
 commands=
-  py.test --benchmark-skip {posargs}
+  python -Wall -m pytest --benchmark-skip {posargs}
 passenv=
   TRAVIS
 
 [testenv:py{38,39,310,311,312}-gevent]
+setenv =
+    PYTHONTRACEMALLOC=1
 extras=
   dev
 commands=
-  python {toxinidir}/pytest-gevent.py --benchmark-skip {posargs}
+  python -Wall {toxinidir}/pytest-gevent.py --benchmark-skip {posargs}
 passenv=
   TRAVIS
 


### PR DESCRIPTION
This PR enables all warnings in the test suite when run in tox.

With this change, additional `ResourceWarning` warnings display. For example:

```
sys:1: ResourceWarning: unclosed file <_io.BufferedRandom name='/tmp/dramatiq-prometheus/gauge_all_2653069.db'>
sys:1: ResourceWarning: unclosed file <_io.BufferedRandom name='/tmp/dramatiq-prometheus/gauge_livesum_2653069.db'>
sys:1: ResourceWarning: unclosed file <_io.BufferedRandom name='/tmp/dramatiq-prometheus/histogram_2653069.db'>
sys:1: ResourceWarning: unclosed file <_io.BufferedRandom name='/tmp/dramatiq-prometheus/counter_2653069.db'>
```

Through trial and error I was able to isolate these four open files to the following test (other tests in that file only trigger warnings about three or fewer unclosed files):

```
tox -e py38 -- tests/test_actors.py::test_actors_can_delay_messages_independent_of_each_other
```

I've not yet identified how these files are getting opened, but with the changes in this PR, it'll be obvious when this issue is resolved.