### PR TITLE
Fix #656 -- Add Python 3.13 support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: |
           sudo apt-get update
           sudo apt-get remove libhashkit2 libmemcached11 || true
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         concurrency: ["cpython", "gevent"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: python -m pip install build

--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -169,7 +169,7 @@ class Actor(Generic[P, R]):
         message = self.message_with_options(args=args, kwargs=kwargs, **options)
         return self.broker.enqueue(message, delay=delay)
 
-    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Any | R | Awaitable[R]:
         """Synchronously call this actor.
 
         Parameters:

--- a/dramatiq/middleware/time_limit.py
+++ b/dramatiq/middleware/time_limit.py
@@ -94,7 +94,7 @@ class _CtypesTimeoutManager(Thread):
         self.logger = logger or get_logger(__name__, type(self))
         self.mu = threading.RLock()
 
-    def _handle(self):
+    def _handle_deadlines(self):
         current_time = monotonic()
         threads_to_kill = []
         with self.mu:
@@ -110,7 +110,7 @@ class _CtypesTimeoutManager(Thread):
     def run(self):
         while True:
             try:
-                self._handle()
+                self._handle_deadlines()
             except Exception:  # pragma: no cover
                 self.logger.exception("Unhandled error while running the time limit handler.")
 

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: System :: Distributed Computing",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",

--- a/tests/middleware/test_time_limit.py
+++ b/tests/middleware/test_time_limit.py
@@ -46,7 +46,7 @@ def test_time_limit_exceeded_worker_messages(raise_thread_exception, caplog):
         1: current_time - 2, 2: current_time - 1, 3: current_time + 50000}
 
     # When the time limit handler is triggered
-    middleware.manager._handle()
+    middleware.manager._handle_deadlines()
 
     # TimeLimitExceeded interrupts are raised in two of the threads
     raise_thread_exception.assert_has_calls([


### PR DESCRIPTION
`threading.Thread` received a new `_handle` attribute in Python 3.13, which clashes with dramatiq's `_CtypesTimeoutManager(Thread)` class. This commit renames the dramatiq method to resolve the conflict.

It also adds Python 3.13 to CI and package classification.