### PR TITLE
Drop official support for Python 3.8 (end of life)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         concurrency: ["cpython", "gevent"]
 
     runs-on: ${{ matrix.os }}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ Here's what it looks like:
   count_words.send("http://example.com")
 
 **Dramatiq** is :doc:`licensed<license>` under the LGPL and it
-officially supports Python 3.8 and later.
+officially supports Python 3.9 and later.
 
 
 Get It Now

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-Dramatiq supports Python versions 3.8 and up and is installable via
+Dramatiq supports Python versions 3.9 and up and is installable via
 `pip`_ or from source.
 
 

--- a/setup.py
+++ b/setup.py
@@ -116,12 +116,11 @@ setup(
     ],
     include_package_data=True,
     install_requires=dependencies,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     extras_require=extra_dependencies,
     entry_points={"console_scripts": ["dramatiq = dramatiq.__main__:main"]},
     scripts=["bin/dramatiq-gevent"],
     classifiers=[
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-  py{38,39,310,311,312,313}{,-gevent}
+  py{39,310,311,312,313}{,-gevent}
   docs
   lint
 
@@ -14,7 +14,7 @@ commands=
 passenv=
   TRAVIS
 
-[testenv:py{38,39,310,311,312,313}-gevent]
+[testenv:py{39,310,311,312,313}-gevent]
 setenv =
     PYTHONTRACEMALLOC=1
 extras=

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-  py{38,39,310,311,312}{,-gevent}
+  py{38,39,310,311,312,313}{,-gevent}
   docs
   lint
 
@@ -14,7 +14,7 @@ commands=
 passenv=
   TRAVIS
 
-[testenv:py{38,39,310,311,312}-gevent]
+[testenv:py{38,39,310,311,312,313}-gevent]
 setenv =
     PYTHONTRACEMALLOC=1
 extras=


### PR DESCRIPTION
This PR also adds 3.13 to tox.ini (as mentioned in https://github.com/Bogdanp/dramatiq/pull/659#issuecomment-2456300003)