### PR TITLE
Introducing dramatiq Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![PyPI version](https://badge.fury.io/py/dramatiq.svg)](https://badge.fury.io/py/dramatiq)
 [![Documentation](https://img.shields.io/badge/doc-latest-brightgreen.svg)](http://dramatiq.io)
 [![Discuss](https://img.shields.io/badge/discuss-online-orange.svg)](https://groups.io/g/dramatiq-users)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20dramatiq%20Guru-006BFF)](https://gurubase.io/g/dramatiq)
 
 *A fast and reliable distributed task processing library for Python 3.*
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [dramatiq Guru](https://gurubase.io/g/dramatiq) to Gurubase. dramatiq Guru uses the data from this repo and data from the [docs](https://dramatiq.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "dramatiq Guru", which highlights that dramatiq now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable dramatiq Guru in Gurubase, just let me know that's totally fine.
