### PR TITLE
fix: correct typing on signal handler

### DIFF
--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -31,6 +31,8 @@ import sys
 import time
 from itertools import chain
 from threading import Event, Thread
+import types
+from typing import Optional
 
 from dramatiq import Broker, ConnectionError, Worker, __version__, get_broker, get_logger
 from dramatiq.canteen import Canteen, canteen_add, canteen_get, canteen_try_init
@@ -559,24 +561,26 @@ def main(args=None):  # noqa
     )
     log_watcher.start()
 
-    def stop_subprocesses(signum):
+    def stop_subprocesses(signum: signal.Signals):
         nonlocal running
         running = False
 
         for proc in chain(worker_processes, fork_processes):
             try:
-                os.kill(proc.pid, signum)
+                os.kill(proc.pid, signum.value)
             except OSError:  # pragma: no cover
                 if proc.exitcode is None:
                     logger.warning("Failed to send %r to PID %d.", signum.name, proc.pid)
 
-    def sighandler(signum, frame):
+    def sighandler(signum: int, frame: Optional[types.FrameType]):
         nonlocal reload_process
+        signum = signal.Signals(signum)
+
         reload_process = signum == getattr(signal, "SIGHUP", None)
         if signum == signal.SIGINT:
             signum = signal.SIGTERM
 
-        logger.info("Sending signal %r to subprocesses...", getattr(signum, "name", signum))
+        logger.info("Sending signal %r to subprocesses...", signum.name)
         stop_subprocesses(signum)
 
     retcode = RET_OK

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -29,9 +29,9 @@ import random
 import signal
 import sys
 import time
+import types
 from itertools import chain
 from threading import Event, Thread
-import types
 from typing import Optional
 
 from dramatiq import Broker, ConnectionError, Worker, __version__, get_broker, get_logger


### PR DESCRIPTION
the `signum` received in the signal handler is an `int`, not a `Signals` object. this leads to errors like so:

```
[2024-11-12 16:49:05,288] [PID 151] [MainThread] [dramatiq.ForkProcess(0)] [INFO] Stopping fork process...
    res = self._popen.wait(timeout)
  File "/usr/local/lib/python3.10/multiprocessing/popen_fork.py", line 43, in wait
    return self.poll(os.WNOHANG if timeout == 0.0 else 0)
  File "/usr/local/lib/python3.10/multiprocessing/popen_fork.py", line 27, in poll
    pid, sts = os.waitpid(self.pid, flag)
  File "/usr/local/lib/python3.10/site-packages/dramatiq/cli.py", line 579, in sighandler
    logger.info("Sending signal %r to subprocesses...", getattr(signum, "name", signum))
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1477, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1624, in _log
    self.handle(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1634, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1696, in callHandlers
    hdlr.handle(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 966, in handle
    self.acquire()
  File "/usr/local/lib/python3.10/logging/__init__.py", line 917, in acquire
    self.lock.acquire()
  File "/usr/local/lib/python3.10/site-packages/dramatiq/cli.py", line 580, in sighandler
    stop_subprocesses(signum)
  File "/usr/local/lib/python3.10/site-packages/dramatiq/cli.py", line 571, in stop_subprocesses
    logger.warning("Failed to send %r to PID %d.", signum.name, proc.pid)
AttributeError: 'int' object has no attribute 'name'
```

here, we correctly type the signal handler functions, and also convert the `int` to a `Signals` for consistency