### PR TITLE
Add dramatiq-workflow link

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -352,3 +352,18 @@ Dramatiq.  For example::
            dramatiq app
 
 If you don't do this, then metrics will likely fail to export properly.
+
+Workflows
+---------
+
+Nested Pipelines and Groups
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Dramatiq supports running tasks in parallel via |group| and in
+sequence via |pipeline|, but it does not provide a built-in way to run
+a pipeline of groups out of the box. If you need more advanced
+orchestration capabilities, such as nesting chains and groups of tasks
+at arbitrary depth, you may find the dramatiq-workflow_ package
+useful.
+
+.. _dramatiq-workflow: https://github.com/Outset-AI/dramatiq-workflow


### PR DESCRIPTION
[As discussed on the mailing list](https://groups.io/g/dramatiq-users/message/311), this adds a link from the Dramatiq docs back to [dramatiq-workflow](https://github.com/Outset-AI/dramatiq-workflow).

Please let me know if you want different wording or move it to a different section! ❤️