### PR TITLE
feat: add ensure_consumer kwarg to before/after_declare_queue to control whether a consumer should be created on a RabbitMQ, then disable consumer thread creation upon message delivery

### DIFF
--- a/dramatiq/middleware/middleware.py
+++ b/dramatiq/middleware/middleware.py
@@ -70,11 +70,11 @@ class Middleware:
         """Called after an actor has been declared.
         """
 
-    def before_declare_queue(self, broker, queue_name):
+    def before_declare_queue(self, broker, queue_name, ensure_consumer=True):
         """Called before a queue is declared.
         """
 
-    def after_declare_queue(self, broker, queue_name):
+    def after_declare_queue(self, broker, queue_name, ensure_consumer=True):
         """Called after a queue has been declared.
 
         This signals that the queue has been registered with the
@@ -84,7 +84,7 @@ class Middleware:
         them until messages are enqueued or consumed.
         """
 
-    def after_declare_delay_queue(self, broker, queue_name):
+    def after_declare_delay_queue(self, broker, queue_name, ensure_consumer=True):
         """Called after a delay queue has been declared.
         """
 

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -219,13 +219,15 @@ class _WorkerMiddleware(Middleware):
         self.logger = get_logger(__name__, type(self))
         self.worker = worker
 
-    def after_declare_queue(self, broker, queue_name):
-        self.logger.debug("Adding consumer for queue %r.", queue_name)
-        self.worker._add_consumer(queue_name)
+    def after_declare_queue(self, broker, queue_name, ensure_consumer=True):
+        if ensure_consumer:
+            self.logger.debug("Adding consumer for queue %r.", queue_name)
+            self.worker._add_consumer(queue_name)
 
-    def after_declare_delay_queue(self, broker, queue_name):
-        self.logger.debug("Adding consumer for delay queue %r.", queue_name)
-        self.worker._add_consumer(queue_name, delay=True)
+    def after_declare_delay_queue(self, broker, queue_name, ensure_consumer=True):
+        if ensure_consumer:
+            self.logger.debug("Adding consumer for delay queue %r.", queue_name)
+            self.worker._add_consumer(queue_name, delay=True)
 
 
 class _ConsumerThread(Thread):


### PR DESCRIPTION
Following the discussion [Issue with RabbitMQ Broker: sending a message to the queue creates a consumer thread locally](https://groups.io/g/dramatiq-users/topic/110212159), this draft illustrates the proposed change.

@Bogdanp I also noticed that there’s no
```python
self.emit_before("declare_delay_queue", delayed_name)
```
callback when the DQ is declared — is that intentional?