### PR TITLE
Fix changelog entry for dramatiq_queue_prefetch

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -575,7 +575,7 @@ Added
 ^^^^^
 
 * `dramatiq_queue_prefetch` environment variable to control the number
-  of messages to prefetch per worker thread.  (`#183`_, `#184`_, `@xelhark`_)
+  of messages to prefetch per worker process.  (`#183`_, `#184`_, `@xelhark`_)
 * The RabbitMQ broker now retries the queue declaration process if an
   error occurs.  (`#179`_, `@davidt99`_)
 * Support for accessing nested broker instances from the CLI.


### PR DESCRIPTION
I believe `dramatiq_queue_prefetch` is per worker process, not per thread.

As per the source code https://github.com/Bogdanp/dramatiq/blob/b372f431ae40ff383a5b450dc37c8e5d5671bf49/dramatiq/worker.py#L41

And this comment https://github.com/Bogdanp/dramatiq/issues/392#issuecomment-815458472

This matches my testing where, when running with 2 threads, I needed to set `dramatiq_queue_prefetch=2` to make each thread process a message, but not to pre-fetch any extra ones.