### PR TITLE
Allow for pipelines to ignore error and continue.

### DIFF
--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -144,6 +144,16 @@ call |pipeline_get_results|::
   for res in pipe.get_results(block=True):
       ...
 
+If you want the actors in the pipeline to keep executing even if
+a actor in it errors out, use the ``pipe_ignore_exception`` option::
+
+  (
+      throws_exception.message(pipe_ignore_exception=True) |
+      will_still_run.message()
+  )
+
+Note that if the ``may_fail`` actor throws an exception,
+the ``will_still_run`` actor will receive ``None`` as input.
 
 Error Reporting
 ---------------


### PR DESCRIPTION
It is useful for me to have a pipeline of messages that execute. However, I want to keep executing the pipeline even if the individual message fails. This pull-request implements that using a new option on the message in the Pipelines middleware.