### PR TITLE
Fix flushing of RabbitMQ queues

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -66,3 +66,4 @@ of those changes to CLEARTYPE SRL.
 | [@5tefan](https://github.com/5tefan/)                  | Stefan Codrescu        |
 | [@kuba-lilz](https://github.com/kuba-lilz/)            | Jakub Kolodziejczyk    |
 | [@dbowring](https://github.com/dbowring/)              | Daniel Bowring         |
+| [@olii](https://github.com/olii)                       | Oliver Nemček          |


### PR DESCRIPTION
This PR fixes a bug when queues on the `broker` are flushed.

The old behavior was incorrect. It didn't flush delayed queues ending with `.DQ` and `.XQ` because the main queue was in the `self.queues_pending` variable (e.g. undeclared yet). We will have to ensure queues exist by declaring them first.

The new behavior doesn't require queues to be declared. If the purge fails and the RabbitMQ server closes the channel, it is recreated again, and the flushing continues.

This PR doesn't come with tests. I was not able to find them for the existing code. Based on that I didn't initiate the discussion as this is only useful in dev/tests environment.
