### PR TITLE
make Prometheus optional

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,9 +38,9 @@ Changed
   (`#640`_, `#641`_, `@z0z0r4`_)
 * The `Retries` middleware now tracks when a message was last requeued
   on retry. (`#629`_, `@kuba-lilz`_)
-* The `prometheus-client` dependency is optional.
-  The `Prometheus` middleware is only loaded when the `prometheus-client`
-  dependency is installed. (`#345`_, `#688`_, `@azmeuk`_)
+* The `prometheus-client` dependency is now optional, and the `Prometheus`
+  middleware is no longer in the default list, and should be added manually.
+   (`#345`_, `#688`_, `@azmeuk`_)
 
 .. _#345: https://github.com/Bogdanp/dramatiq/issues/345
 .. _#629: https://github.com/Bogdanp/dramatiq/pull/629

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,10 +38,16 @@ Changed
   (`#640`_, `#641`_, `@z0z0r4`_)
 * The `Retries` middleware now tracks when a message was last requeued
   on retry. (`#629`_, `@kuba-lilz`_)
+* The `prometheus-client` dependency is optional.
+  The `Prometheus` middleware is only loaded when the `prometheus-client`
+  dependency is installed. (`#345`_, `#688`_, `@azmeuk`_)
 
+.. _#345: https://github.com/Bogdanp/dramatiq/issues/345
 .. _#629: https://github.com/Bogdanp/dramatiq/pull/629
 .. _#640: https://github.com/Bogdanp/dramatiq/issues/640
 .. _#641: https://github.com/Bogdanp/dramatiq/pull/641
+.. _#688: https://github.com/Bogdanp/dramatiq/pull/688
+.. _@azmeuk: https://github.com/azmeuk
 .. _@kuba-lilz: https://github.com/kuba-lilz
 .. _@z0z0r4: https://github.com/z0z0r4
 

--- a/dramatiq/middleware/__init__.py
+++ b/dramatiq/middleware/__init__.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import importlib
-
 from .age_limit import AgeLimit
 from .asyncio import AsyncIO
 from .callbacks import Callbacks
@@ -24,7 +22,6 @@ from .current_message import CurrentMessage
 from .group_callbacks import GroupCallbacks
 from .middleware import Middleware, MiddlewareError, SkipMessage
 from .pipelines import Pipelines
-from .prometheus import Prometheus
 from .retries import Retries
 from .shutdown import Shutdown, ShutdownNotifications
 from .threading import Interrupt, raise_thread_exception
@@ -48,10 +45,3 @@ __all__ = [
 default_middleware = [
     AgeLimit, TimeLimit, ShutdownNotifications, Callbacks, Pipelines, Retries
 ]
-
-try:
-    if importlib.util.find_spec("prometheus_client"):
-        default_middleware.insert(0, Prometheus)
-        __all__.append("Prometheus")
-except ModuleNotFoundError:
-    pass

--- a/dramatiq/middleware/__init__.py
+++ b/dramatiq/middleware/__init__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import importlib
+
 from .age_limit import AgeLimit
 from .asyncio import AsyncIO
 from .callbacks import Callbacks
@@ -44,5 +46,12 @@ __all__ = [
 
 #: The list of middleware that are enabled by default.
 default_middleware = [
-    Prometheus, AgeLimit, TimeLimit, ShutdownNotifications, Callbacks, Pipelines, Retries
+    AgeLimit, TimeLimit, ShutdownNotifications, Callbacks, Pipelines, Retries
 ]
+
+try:
+    if importlib.util.find_spec("prometheus_client"):
+        default_middleware.append(Prometheus)
+        __all__.append("Prometheus")
+except ModuleNotFoundError:
+    pass

--- a/dramatiq/middleware/__init__.py
+++ b/dramatiq/middleware/__init__.py
@@ -40,7 +40,7 @@ __all__ = [
     # Middlewares
     "AgeLimit", "AsyncIO", "Callbacks", "CurrentMessage", "GroupCallbacks",
     "Pipelines", "Retries", "Shutdown", "ShutdownNotifications", "TimeLimit",
-    "TimeLimitExceeded", "Prometheus",
+    "TimeLimitExceeded",
 ]
 
 
@@ -51,7 +51,7 @@ default_middleware = [
 
 try:
     if importlib.util.find_spec("prometheus_client"):
-        default_middleware.append(Prometheus)
+        default_middleware.insert(0, Prometheus)
         __all__.append("Prometheus")
 except ModuleNotFoundError:
     pass

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,6 @@ with open(rel("dramatiq", "__init__.py"), "r") as f:
         raise RuntimeError("Version marker not found.")
 
 
-dependencies = [
-    "prometheus-client>=0.2",
-]
-
 extra_dependencies = {
     "gevent": [
         "gevent>=1.1",
@@ -50,6 +46,10 @@ extra_dependencies = {
 
     "memcached": [
         "pylibmc>=1.5,<2.0",
+    ],
+
+    "prometheus": [
+        "prometheus-client>=0.2",
     ],
 
     "rabbitmq": [
@@ -115,7 +115,6 @@ setup(
         "dramatiq.results.backends",
     ],
     include_package_data=True,
-    install_requires=dependencies,
     python_requires=">=3.9",
     extras_require=extra_dependencies,
     entry_points={"console_scripts": ["dramatiq = dramatiq.__main__:main"]},

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -25,13 +25,13 @@ def test_broker_uses_rabbitmq_if_not_set():
 
 @skip_on_windows
 def test_broker_middleware_can_be_added_before_other_middleware(stub_broker):
-    from dramatiq.middleware import Prometheus
+    from dramatiq.middleware import AgeLimit
 
     # Given that I have a custom middleware
     empty_middleware = EmptyMiddleware()
 
-    # If I add it before the Prometheus middleware
-    stub_broker.add_middleware(empty_middleware, before=Prometheus)
+    # If I add it before the AgeLimit middleware
+    stub_broker.add_middleware(empty_middleware, before=AgeLimit)
 
     # I expect it to be the first middleware
     assert stub_broker.middleware[0] == empty_middleware
@@ -39,13 +39,13 @@ def test_broker_middleware_can_be_added_before_other_middleware(stub_broker):
 
 @skip_on_windows
 def test_broker_middleware_can_be_added_after_other_middleware(stub_broker):
-    from dramatiq.middleware import Prometheus
+    from dramatiq.middleware import AgeLimit
 
     # Given that I have a custom middleware
     empty_middleware = EmptyMiddleware()
 
-    # If I add it after the Prometheus middleware
-    stub_broker.add_middleware(empty_middleware, after=Prometheus)
+    # If I add it after the AgeLimit middleware
+    stub_broker.add_middleware(empty_middleware, after=AgeLimit)
 
     # I expect it to be the second middleware
     assert stub_broker.middleware[1] == empty_middleware
@@ -63,7 +63,7 @@ def test_broker_middleware_can_fail_to_be_added_before_or_after_missing_middlewa
 
 @skip_on_windows
 def test_broker_middleware_cannot_be_addwed_both_before_and_after(stub_broker):
-    from dramatiq.middleware import Prometheus
+    from dramatiq.middleware import AgeLimit
 
     # Given that I have a custom middleware
     empty_middleware = EmptyMiddleware()
@@ -71,7 +71,7 @@ def test_broker_middleware_cannot_be_addwed_both_before_and_after(stub_broker):
     # If I add it with both before and after parameters
     # I expect an AssertionError to be raised
     with pytest.raises(AssertionError):
-        stub_broker.add_middleware(empty_middleware, before=Prometheus, after=Prometheus)
+        stub_broker.add_middleware(empty_middleware, before=AgeLimit, after=AgeLimit)
 
 
 def test_can_instantiate_brokers_without_middleware():


### PR DESCRIPTION
I applied the patch proposed in #345 to make the Prometheus middleware optional:

- prometheus-client is now an optional dependency
- The Prometheus middleware is only loaded if the prometheus_client is installed.

fixes #345