### PR TITLE
Add repr to MessageProxy

### DIFF
--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -383,6 +383,9 @@ class MessageProxy:
     def __str__(self):
         return str(self._message)
 
+    def __repr__(self):
+        return f"<{self.__class__.__qualname__} {self._message!r}>"
+
     def __lt__(self, other):
         # This can get called if two messages have the same priority
         # in a queue.  If that's the case, we don't care which runs


### PR DESCRIPTION
Small change to improve developer experience with Dramatiq+Sentry and possibly any other error aggregation platform.

Currently error messages in Sentry look like this:

![image](https://github.com/user-attachments/assets/91566242-65af-491b-92e6-a01c3d9f9263)

This is caused by the following code is responsible for formatting log params in Sentry: https://github.com/getsentry/sentry-python/blob/adcfa0f6abf8850f3b007bde609d0f943f621786/sentry_sdk/logger.py#L24-L32. Sentry has its reasons to do this - `__str__` is more lossy than `__repr__`, for example exceptions stringify to their arguments, losing their class name.

After this change MessageProxy repr looks as follows:

`<MessageProxy Message(queue_name='default', actor_name='actor_name', args=('arg',), kwargs={}, options={}, message_id='fe5511da-59ed-4b45-80f2-526d02c935fb', message_timestamp=1743773870061)>`

Existing logging will not be affected because Dramatiq uses "%s" for message formatting and `MessageProxy.__str__` remains the same..