### PR TITLE
fix: join_queue implementation for compatibility with gevent 25.4.1

### DIFF
--- a/dramatiq/common.py
+++ b/dramatiq/common.py
@@ -100,7 +100,7 @@ def join_queue(queue, timeout=None):
         queue.join()
         join_complete.set()
 
-    join_thread = threading.Thread(target=join_and_signal)
+    join_thread = threading.Thread(target=join_and_signal, name="join_and_signal_thread")
     join_thread.daemon = True
     join_thread.start()
 

--- a/dramatiq/common.py
+++ b/dramatiq/common.py
@@ -82,7 +82,6 @@ def join_queue(queue, timeout=None):
     """The join() method of standard queues in Python doesn't support
     timeouts.  This implements the same functionality as that method,
     with optional timeout support, using only exposed Queue interfaces.
-    This implementation is compatible with gevent.
 
     Raises:
       QueueJoinTimeout: When the timeout is reached.


### PR DESCRIPTION
Fixes compatibility issues with gevent 25.4.1, released 17th April 2025. See https://github.com/gevent/gevent/issues/2099

The issue caused dramatiq's gevent test suite to fail.

