### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,11 @@
-# Issues
+---
+name: Bug report
+about: Github issues are primarily for bugs
+title: ''
+labels: ''
+assignees: ''
 
-GitHub issues are for bugs.  If you have questions, please ask them on the [mailing list](https://groups.io/g/dramatiq-users/topics).
+---
 
 ## Checklist
 
@@ -8,6 +13,7 @@ GitHub issues are for bugs.  If you have questions, please ask them on the [mail
 * [ ] Did you include a minimal, reproducible example?
 * [ ] What OS are you using?
 * [ ] What version of Dramatiq are you using?
+* [ ] What version of Python are you using?
 * [ ] What did you do?
 * [ ] What did you expect would happen?
 * [ ] What happened?
@@ -21,6 +27,11 @@ GitHub issues are for bugs.  If you have questions, please ask them on the [mail
 ## What version of Dramatiq are you using?
 
 <!-- run this command to find out: python -c 'import dramatiq; print(dramatiq.__version__)' -->
+
+
+## What version of Python are you using?
+
+<!-- run this command to find out: python --version -->
 
 
 ## What did you do?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions
+    url: https://groups.io/g/dramatiq-users
+    about:  If you have questions, please ask them on the discussion Board.
+  - name: Feature Requests
+    url: https://groups.io/g/dramatiq-users
+    about:  If you want to request or suggest a feature, please start a discussion on the discussion Board.


### PR DESCRIPTION
I think the current issue template is being ignored by github.

This should make it work again.

Plus the config.yml should make github suggestion the discussion board when opening an issue.