### PR TITLE
Close write_pipe after forking

### DIFF
--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -513,6 +513,7 @@ def main(args=None):  # noqa
         worker_pipes.append(read_pipe)
         worker_processes.append(proc)
         worker_process_events.append(event)
+        write_pipe.close()
 
     # Wait for all worker processes to come online before starting the
     # fork processes.  This is required to avoid race conditions like
@@ -534,6 +535,7 @@ def main(args=None):  # noqa
         proc.start()
         fork_pipes.append(read_pipe)
         fork_processes.append(proc)
+        write_pipe.close()
 
     parent_read_pipe, parent_write_pipe = multiprocessing.Pipe(duplex=False)
     logger = setup_parent_logging(args, stream=StreamablePipe(parent_write_pipe))


### PR DESCRIPTION
The write_pipe never goes out of scope and so the last process's write_pipe is never closed by the watcher process, which results in a hang on read() from this pipe in log_watcher when the worker process is killed, and blocking all worker processes when their respective write pipe buffers are exhausted.