### PR TITLE
fix: ensure requeue timestamp is greater than message timestamp

### DIFF
--- a/dramatiq/middleware/retries.py
+++ b/dramatiq/middleware/retries.py
@@ -99,7 +99,12 @@ class Retries(Middleware):
 
         message.options["retries"] += 1
         message.options["traceback"] = traceback.format_exc(limit=30)
-        message.options["requeue_timestamp"] = int(time.time() * 1000)
+        requeue_timestamp = int(time.time() * 1000)
+
+        # Ensure requeue_timestamp is greater than message_timestamp
+        if requeue_timestamp <= message.message_timestamp:
+            requeue_timestamp = message.message_timestamp + 1
+        message.options["requeue_timestamp"] = requeue_timestamp
 
         max_retries = message.options.get("max_retries", actor.options.get("max_retries", self.max_retries))
         retry_when = actor.options.get("retry_when", self.retry_when)


### PR DESCRIPTION
[This test](https://github.com/Bogdanp/dramatiq/blob/a3c1d5f1775a576d7f1e7d7f3b0efe223abccfa7/tests/middleware/test_retries.py#L323
) surfaces a problem with `Retries` middleware logic.

In some scenarios `requeue_timestamp` may be equal to `message_timestamp`, causing the [test to fail](https://github.com/Bogdanp/dramatiq/actions/runs/15274257593/job/42956697314?pr=709)

The fix ensures that the `requeue_timestamp` is always greater than `message_timestamp`.