### PR TITLE
Fix flaky test test_message_contains_requeue_time_after_retry

### DIFF
--- a/tests/middleware/test_retries.py
+++ b/tests/middleware/test_retries.py
@@ -329,7 +329,7 @@ def test_message_contains_requeue_time_after_retry(stub_broker, stub_worker):
     max_retries = 2
 
     # And an actor that raises an exception and should be retried
-    @dramatiq.actor(max_retries=max_retries, min_backoff=500, max_backoff=500)
+    @dramatiq.actor(max_retries=max_retries, min_backoff=100, max_backoff=100)
     def do_work():
 
         current_message = dramatiq.middleware.CurrentMessage.get_current_message()
@@ -339,7 +339,8 @@ def test_message_contains_requeue_time_after_retry(stub_broker, stub_worker):
 
         raise RuntimeError()
 
-    message = do_work.send()
+    # Send message for the actor (use delay so first requeue_timestamp is after message_timestamp)
+    message = do_work.send_with_options(delay=100)
 
     # When I join on the queue and run the actor
     stub_broker.join(do_work.queue_name)


### PR DESCRIPTION
The problem was that the first entry of `requeue_timestamps` was sometimes equal to the `message_timestamp`, since the Stub broker processes the message so quickly.
Increasing `min_backoff` has no effect on this, since that only kicks in once the message fails for the first time.

My fix is to add delay to test message to ensure that the first `requeue_timestamps` is always after `message_timestamp`.

Alternative PR to #710 