### PR TITLE
Change `compute_backoff` implementation to respect min_backoff

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,19 @@ All notable changes to this project will be documented in this file.
 `Unreleased`_
 -------------
 
+Fixed
+^^^^^
+
+* Fixed the way that backoff time is calculated for retries so that the
+  first backoff is not less than ``min_backoff``.
+  This means that each retry backoff is now, on average, twice as long.
+  To avoid this effect, you can halve your ``min_backoff``
+  (which should now be correctly observed).
+  (`#651`_, `#721`_, `@LincolnPuzey`_)
+
+.. _#651: https://github.com/Bogdanp/dramatiq/issues/651
+.. _#721: https://github.com/Bogdanp/dramatiq/pull/721
+
 Changed
 ^^^^^^^
 

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -125,7 +125,9 @@ def test_rabbitmq_actors_retry_with_backoff_on_failure(rabbitmq_broker, rabbitmq
     succeeded.wait(timeout=30)
 
     # I expect backoff time to have passed between success and failure
-    assert 500 <= success_time - failure_time <= 1500
+    assert 1000 <= success_time - failure_time <= (2000 + 200)
+    # The first backoff time should be 100-200% of min_backoff.
+    # Add an extra 200 milliseconds to account for processing and to prevent flakiness.
 
 
 def test_rabbitmq_actors_can_retry_multiple_times(rabbitmq_broker, rabbitmq_worker):


### PR DESCRIPTION
Closes #651

Currently, because the 'jittering' makes the `backoff` smaller, for the first attempt, the returned value will be smaller than `factor` - which is `min_backoff`. This is the bug reported.

My change here is to make the 'jittering' _increase_ the backoff, so it is never smaller than `factor` (`min_backoff`).

This implementation does mean there will be no jittering once max_backoff is reached.
Is that a problem? @Bogdanp Can I get your opinion?