### PR TITLE
prometheus: remove unused LOCK_PATH

### DIFF
--- a/dramatiq/middleware/prometheus.py
+++ b/dramatiq/middleware/prometheus.py
@@ -23,9 +23,6 @@ from ..common import current_millis
 from ..logging import get_logger
 from .middleware import Middleware
 
-#: The path to the file to use to race Exposition servers against one another.
-LOCK_PATH = os.getenv("dramatiq_prom_lock", "%s/dramatiq-prometheus.lock" % tempfile.gettempdir())
-
 #: The path to store the prometheus database files.  This path is
 #: cleared before every run.
 DB_PATH = os.getenv("dramatiq_prom_db", "%s/dramatiq-prometheus" % tempfile.gettempdir())


### PR DESCRIPTION
unused since 1ff83f576f82380a4df57e9da9d333913a72f839,

Looks like it was no accident - this change enabled middleware to define "main process forks" - https://github.com/Bogdanp/dramatiq/commit/1ff83f576f82380a4df57e9da9d333913a72f839#diff-73ebb8c3b1b4e359737d3c991b8945a4f07b784729b051ecaa3cc0843d903565R330-R332, see https://dramatiq.io/reference.html#dramatiq.Middleware.forks.