### PR TITLE
Make `backend` a required argument to `ResultMiddleware`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,10 +27,13 @@ Changed
 * The `prometheus-client` dependency is now optional, and the `Prometheus`
   middleware is no longer in the default list, and should be added manually.
   (`#345`_, `#688`_, `@azmeuk`_)
+* The ``backend`` argument to the |Results| middleware is now required.
+  (`#728`_, `@LincolnPuzey`_)
 
 .. _#345: https://github.com/Bogdanp/dramatiq/issues/345
 .. _#688: https://github.com/Bogdanp/dramatiq/pull/688
 .. _@azmeuk: https://github.com/azmeuk
+.. _#728: https://github.com/Bogdanp/dramatiq/pull/728
 
 `1.18.0`_ -- 2025-05-29
 -----------------------

--- a/dramatiq/results/middleware.py
+++ b/dramatiq/results/middleware.py
@@ -67,7 +67,7 @@ class Results(Middleware):
       run out!
     """
 
-    def __init__(self, *, backend=None, store_results=False, result_ttl=None):
+    def __init__(self, *, backend, store_results=False, result_ttl=None):
         self.logger = get_logger(__name__, type(self))
         self.backend = backend
         self.store_results = store_results


### PR DESCRIPTION
Revisiting #332 

Change so that a Result backend must be provided when creating the `ResultMiddleware`.

Technically a breaking change, but v2 is planned to be the next release.

Previously, using the middleware with `backend=None` would be broken if you ever tried to store a result. So you could do that and never store a result, but that is sort of pointless.