### PR TITLE
Improve typing coverage on external API, in particular Worker and Broker classes

### DIFF
--- a/dramatiq/actor.py
+++ b/dramatiq/actor.py
@@ -25,7 +25,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Dict,
     Generic,
     Optional,
     TypeVar,
@@ -74,7 +73,7 @@ class Actor(Generic[P, R]):
         actor_name: str,
         queue_name: str,
         priority: int,
-        options: Dict[str, Any],
+        options: dict[str, Any],
     ) -> None:
         if actor_name in broker.actors:
             raise ValueError(f"An actor named {actor_name!r} is already registered.")
@@ -110,7 +109,7 @@ class Actor(Generic[P, R]):
         self,
         *,
         args: tuple = (),
-        kwargs: Optional[Dict[str, Any]] = None,
+        kwargs: Optional[dict[str, Any]] = None,
         **options,
     ) -> Message[R]:
         """Build a message with an arbitrary set of processing options.
@@ -158,7 +157,7 @@ class Actor(Generic[P, R]):
         self,
         *,
         args: tuple = (),
-        kwargs: Optional[Dict[str, Any]] = None,
+        kwargs: Optional[dict[str, Any]] = None,
         delay: Optional[timedelta | int] = None,
         **options,
     ) -> Message[R]:

--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -15,12 +15,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from .errors import ActorNotFound
 from .logging import get_logger
 from .middleware import MiddlewareError, default_middleware
 from .results import ResultBackend, Results
+
+if TYPE_CHECKING:
+    from .actor import Actor
 
 #: The global broker instance.
 global_broker: Optional["Broker"] = None
@@ -61,7 +64,7 @@ def get_broker() -> "Broker":
     return global_broker
 
 
-def set_broker(broker: "Broker"):
+def set_broker(broker: "Broker") -> None:
     """Configure the global broker instance.
 
     Parameters:
@@ -192,7 +195,7 @@ class Broker:
         """
         raise NotImplementedError
 
-    def declare_actor(self, actor):  # pragma: no cover
+    def declare_actor(self, actor: Actor) -> None:  # pragma: no cover
         """Declare a new actor on this broker.  Declaring an Actor
         twice replaces the first actor with the second by name.
 

--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -163,8 +163,10 @@ class Broker:
                 )
 
         if before or after:
-            for i, m in enumerate(self.middleware):  # noqa
-                if isinstance(m, before or after):
+            for i, m in enumerate(self.middleware):  # noqa: B007
+                if before and isinstance(m, before):
+                    break
+                if after and isinstance(m, after):
                     break
             else:
                 raise ValueError("Middleware %r not found" % (before or after))
@@ -358,7 +360,7 @@ class Consumer:
         default implementation does nothing.
 
         Parameters:
-          messages(list[MessageProxy]): The messages to requeue.
+          messages(Iterable[MessageProxy]): The messages to requeue.
         """
 
     def __next__(self):  # pragma: no cover
@@ -385,7 +387,7 @@ class MessageProxy:
     if TYPE_CHECKING:
         queue_name: str
         actor_name: str
-        args: tuple
+        args: tuple[Any, ...]
         kwargs: dict[str, Any]
         options: dict[str, Any]
         message_id: str

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -22,7 +22,7 @@ import warnings
 from functools import partial
 from itertools import chain
 from threading import Event, local
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import pika
 
@@ -91,10 +91,10 @@ class RabbitmqBroker(Broker):
         self,
         *,
         confirm_delivery: bool = False,
-        url: Optional[str] = None,
+        url: Optional[Union[str, list[str]]] = None,
         middleware: Optional[list[Middleware]] = None,
         max_priority: Optional[int] = None,
-        parameters: Any = None,
+        parameters: Optional[list[dict[str, Any]]] = None,
         **kwargs: Any,
     ):
         super().__init__(middleware=middleware)

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -21,6 +21,7 @@ import time
 import warnings
 from os import path
 from threading import Lock
+from typing import Optional
 from uuid import uuid4
 
 import redis
@@ -125,7 +126,7 @@ class RedisBroker(Broker):
     def consumer_class(self):
         return _RedisConsumer
 
-    def consume(self, queue_name, prefetch=1, timeout=5000):
+    def consume(self, queue_name: str, prefetch: int = 1, timeout: int = 5000) -> Consumer:
         """Create a new consumer for a queue.
 
         Parameters:
@@ -138,7 +139,7 @@ class RedisBroker(Broker):
         """
         return self.consumer_class(self, queue_name, prefetch, timeout)
 
-    def declare_queue(self, queue_name):
+    def declare_queue(self, queue_name: str) -> None:
         """Declare a queue.  Has no effect if a queue with the given
         name has already been declared.
 
@@ -154,7 +155,7 @@ class RedisBroker(Broker):
             self.delay_queues.add(delayed_name)
             self.emit_after("declare_delay_queue", delayed_name)
 
-    def enqueue(self, message, *, delay=None):
+    def enqueue(self, message, *, delay: Optional[int] = None) -> Message:
         """Enqueue a message.
 
         Parameters:
@@ -192,7 +193,7 @@ class RedisBroker(Broker):
         self.emit_after("enqueue", message, delay)
         return message
 
-    def get_declared_queues(self):
+    def get_declared_queues(self) -> set[str]:
         """Get all declared queues.
 
         Returns:
@@ -201,7 +202,7 @@ class RedisBroker(Broker):
         """
         return self.queues.copy()
 
-    def flush(self, queue_name):
+    def flush(self, queue_name: str) -> None:
         """Drop all the messages from a queue.
 
         Parameters:
@@ -210,12 +211,12 @@ class RedisBroker(Broker):
         for name in (queue_name, dq_name(queue_name)):
             self.do_purge(name)
 
-    def flush_all(self):
+    def flush_all(self) -> None:
         """Drop all messages from all declared queues."""
         for queue_name in self.queues:
             self.flush(queue_name)
 
-    def join(self, queue_name, *, interval=100, timeout=None):
+    def join(self, queue_name: str, *, interval: int = 100, timeout: Optional[int] = None) -> None:
         """Wait for all the messages on the given queue to be
         processed.  This method is only meant to be used in tests to
         wait for all the messages in a queue to be processed.
@@ -242,7 +243,7 @@ class RedisBroker(Broker):
 
             time.sleep(interval / 1000)
 
-    def _should_do_maintenance(self, command):
+    def _should_do_maintenance(self, command: str) -> int:
         return int(
             command not in MAINTENANCE_COMMAND_BLACKLIST
             and random.randint(1, MAINTENANCE_SCALE) <= self.maintenance_chance

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -155,7 +155,7 @@ class RedisBroker(Broker):
             self.delay_queues.add(delayed_name)
             self.emit_after("declare_delay_queue", delayed_name)
 
-    def enqueue(self, message, *, delay: Optional[int] = None) -> Message:
+    def enqueue(self, message: Message, *, delay: Optional[int] = None) -> Message:
         """Enqueue a message.
 
         Parameters:

--- a/dramatiq/brokers/stub.py
+++ b/dramatiq/brokers/stub.py
@@ -82,7 +82,7 @@ class StubBroker(Broker):
         self.delay_queues.add(delayed_name)
         self.emit_after("declare_delay_queue", delayed_name)
 
-    def enqueue(self, message, *, delay: Optional[int] = None) -> Message:
+    def enqueue(self, message: Message, *, delay: Optional[int] = None) -> Message:
         """Enqueue a message.
 
         Parameters:
@@ -159,8 +159,8 @@ class StubBroker(Broker):
         deadline = timeout and time.monotonic() + timeout / 1000
         while True:
             for queue in queues:
-                timeout_ = deadline and deadline - time.monotonic()
-                join_queue(queue, timeout=timeout_)
+                join_timeout = deadline and deadline - time.monotonic()
+                join_queue(queue, timeout=join_timeout)
 
             # We cycle through $queue then $queue.DQ then $queue
             # again in case the messages that were on the DQ got

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -520,7 +520,7 @@ def fork_process(args, fork_id, fork_path, logging_pipe):
     return sys.exit(func())
 
 
-def main(args=None):  # noqa
+def main(args=None):  # noqa: C901
     args = args or make_argument_parser().parse_args()
     for path in args.path:
         sys.path.insert(0, path)

--- a/dramatiq/common.py
+++ b/dramatiq/common.py
@@ -14,16 +14,18 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import threading
 from os import getenv
 from queue import Empty
 from random import uniform
 from time import time
+from typing import Union
 
 from .errors import QueueJoinTimeout
 
 
-def getenv_int(name):
+def getenv_int(name: str) -> Union[int, None]:
     """Parse an optional environment variable as an integer."""
     v = getenv(name, None)
     if v is None:
@@ -34,7 +36,9 @@ def getenv_int(name):
         raise ValueError("invalid integer value for env var %r: %r" % (name, v)) from None
 
 
-def compute_backoff(attempts, *, factor=5, jitter=True, max_backoff=2000, max_exponent=32):
+def compute_backoff(
+    attempts: int, *, factor: int = 5, jitter: bool = True, max_backoff: int = 2000, max_exponent: int = 32
+) -> tuple[int, int]:
     """Compute an exponential backoff value based on some number of attempts.
 
     Parameters:
@@ -66,7 +70,7 @@ def compute_backoff(attempts, *, factor=5, jitter=True, max_backoff=2000, max_ex
     return attempts + 1, backoff
 
 
-def current_millis():
+def current_millis() -> int:
     """Returns the current UNIX time in milliseconds."""
     return int(time() * 1000)
 
@@ -134,14 +138,14 @@ def join_all(joinables, timeout):
         timeout = max(0, timeout - elapsed)
 
 
-def q_name(queue_name):
+def q_name(queue_name: str) -> str:
     """Returns the canonical queue name for a given queue."""
     if queue_name.endswith(".DQ") or queue_name.endswith(".XQ"):
         return queue_name[:-3]
     return queue_name
 
 
-def dq_name(queue_name):
+def dq_name(queue_name: str) -> str:
     """Returns the delayed queue name for a given queue.  If the given
     queue name already belongs to a delayed queue, then it is returned
     unchanged.
@@ -154,7 +158,7 @@ def dq_name(queue_name):
     return queue_name + ".DQ"
 
 
-def xq_name(queue_name):
+def xq_name(queue_name: str) -> str:
     """Returns the dead letter queue name for a given queue.  If the
     given queue name belongs to a delayed queue, the dead letter queue
     name for the original queue is generated.

--- a/dramatiq/composition.py
+++ b/dramatiq/composition.py
@@ -33,7 +33,7 @@ class pipeline:
     next one in line.
 
     Parameters:
-      children(Iterator[Message|pipeline]): A sequence of messages or
+      children(Iterable[Message|pipeline]): A sequence of messages or
         pipelines.  Child pipelines are flattened into the resulting
         pipeline.
       broker(Broker): The broker to run the pipeline on.  Defaults to

--- a/dramatiq/encoder.py
+++ b/dramatiq/encoder.py
@@ -23,7 +23,7 @@ import typing
 from .errors import DecodeError
 
 #: Represents the contents of a Message object as a dict.
-MessageData = typing.Dict[str, typing.Any]
+MessageData = dict[str, typing.Any]
 
 
 class Encoder(abc.ABC):

--- a/dramatiq/errors.py
+++ b/dramatiq/errors.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional
+
 
 class DramatiqError(Exception):  # pragma: no cover
     """Base class for all dramatiq errors."""
@@ -22,7 +24,7 @@ class DramatiqError(Exception):  # pragma: no cover
     def __init__(self, message):
         self.message = message
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.message) or repr(self.message)
 
 
@@ -79,6 +81,6 @@ class Retry(DramatiqError):
     retried after at least that amount of time (in milliseconds).
     """
 
-    def __init__(self, message="", delay=None):
+    def __init__(self, message: str = "", delay: Optional[int] = None):
         super().__init__(message)
         self.delay = delay

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -18,7 +18,7 @@
 import dataclasses
 import time
 import uuid
-from typing import Any, Dict, Generic, Optional, Tuple, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from .broker import get_broker
 from .composition import pipeline
@@ -75,8 +75,8 @@ class Message(Generic[R]):
     queue_name: str
     actor_name: str
     args: tuple
-    kwargs: Dict[str, Any]
-    options: Dict[str, Any]
+    kwargs: dict[str, Any]
+    options: dict[str, Any]
     message_id: str = dataclasses.field(default_factory=generate_unique_id)
     message_timestamp: int = dataclasses.field(default_factory=lambda: int(time.time() * 1000))
 
@@ -91,7 +91,7 @@ class Message(Generic[R]):
         """Combine this message into a pipeline with "other"."""
         return pipeline([self, other])
 
-    def asdict(self) -> Dict[str, Any]:
+    def asdict(self) -> dict[str, Any]:
         """Convert this message to a dictionary."""
         # For backward compatibility, we can't use `dataclasses.asdict`
         # because it creates a copy of all values, including `options`.
@@ -178,11 +178,11 @@ class Message(Generic[R]):
     _asdict = asdict
 
     @property
-    def _field_defaults(self) -> Dict[str, Any]:
+    def _field_defaults(self) -> dict[str, Any]:
         return {f.name: f.default for f in dataclasses.fields(self) if f.default is not dataclasses.MISSING}
 
     @property
-    def _fields(self) -> Tuple[str, ...]:
+    def _fields(self) -> tuple[str, ...]:
         return tuple(f.name for f in dataclasses.fields(self))
 
     def _replace(self, **changes) -> "Message[R]":

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -74,7 +74,7 @@ class Message(Generic[R]):
 
     queue_name: str
     actor_name: str
-    args: tuple
+    args: tuple[Any, ...]
     kwargs: dict[str, Any]
     options: dict[str, Any]
     message_id: str = dataclasses.field(default_factory=generate_unique_id)

--- a/dramatiq/results/backend.py
+++ b/dramatiq/results/backend.py
@@ -97,11 +97,11 @@ class ResultBackend:
             result = self._get(message_key)
             if result is Missing and block:
                 attempts, delay = compute_backoff(attempts, factor=BACKOFF_FACTOR)
-                delay_ = delay / 1000
-                if time.monotonic() + delay_ > end_time:
+                delay_seconds = delay / 1000
+                if time.monotonic() + delay_seconds > end_time:
                     raise ResultTimeout(message)
 
-                time.sleep(delay_)
+                time.sleep(delay_seconds)
                 continue
 
             elif result is Missing:

--- a/dramatiq/results/backend.py
+++ b/dramatiq/results/backend.py
@@ -97,11 +97,11 @@ class ResultBackend:
             result = self._get(message_key)
             if result is Missing and block:
                 attempts, delay = compute_backoff(attempts, factor=BACKOFF_FACTOR)
-                delay /= 1000
-                if time.monotonic() + delay > end_time:
+                delay_ = delay / 1000
+                if time.monotonic() + delay_ > end_time:
                     raise ResultTimeout(message)
 
-                time.sleep(delay)
+                time.sleep(delay_)
                 continue
 
             elif result is Missing:

--- a/dramatiq/results/backends/stub.py
+++ b/dramatiq/results/backends/stub.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 from ..backend import Missing, ResultBackend
 
@@ -30,7 +30,7 @@ class StubBackend(ResultBackend):
         result data.  Defaults to :class:`.JSONEncoder`.
     """
 
-    results: Dict[str, Tuple[Optional[str], Optional[float]]] = {}
+    results: dict[str, tuple[Optional[str], Optional[float]]] = {}
 
     def _get(self, message_key):
         data, expiration = self.results.get(message_key, (None, None))

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from functools import lru_cache
 from queue import Empty, PriorityQueue
 from threading import Event, Thread
-from typing import Iterable, Optional, Union
+from typing import TYPE_CHECKING, Iterable, Optional, Union
 
 from .broker import Broker, Consumer, MessageProxy
 from .common import current_millis, iter_queue, join_all, q_name
@@ -365,7 +365,8 @@ class _ConsumerThread(Thread):
         individual messages, signaling that each message is ready to
         be acked or rejected.
         """
-        assert self.consumer
+        if TYPE_CHECKING:
+            assert self.consumer
         while True:
             try:
                 if message.failed:
@@ -418,7 +419,8 @@ class _ConsumerThread(Thread):
         connection error to move unacked messages back to their
         respective queues asap.
         """
-        assert self.consumer
+        if TYPE_CHECKING:
+            assert self.consumer
         self.consumer.requeue(messages)
 
     def pause(self) -> None:

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -61,7 +61,7 @@ class Worker:
 
     Parameters:
       broker(Broker)
-      queues(Set[str]): An optional subset of queues to listen on.  By
+      queues(set[str]): An optional subset of queues to listen on.  By
         default, if this is not provided, the worker will listen on
         all declared queues.
       worker_timeout(int): The number of milliseconds workers should
@@ -88,7 +88,7 @@ class Worker:
         self.worker_timeout = worker_timeout
         self.worker_threads = worker_threads
 
-    def start(self):
+    def start(self) -> None:
         """Initialize the worker boot sequence and start up all the
         worker threads.
         """
@@ -101,7 +101,7 @@ class Worker:
 
         self.broker.emit_after("worker_boot", self)
 
-    def pause(self):
+    def pause(self) -> None:
         """Pauses all the worker threads."""
         for child in chain(self.consumers.values(), self.workers):
             child.pause()
@@ -109,12 +109,12 @@ class Worker:
         for child in chain(self.consumers.values(), self.workers):
             child.paused_event.wait()
 
-    def resume(self):
+    def resume(self) -> None:
         """Resumes all the worker threads."""
         for child in chain(self.consumers.values(), self.workers):
             child.resume()
 
-    def stop(self, timeout=600000):
+    def stop(self, timeout: int = 600000):
         """Gracefully stop the Worker and all of its consumers and
         workers.
 
@@ -161,7 +161,7 @@ class Worker:
         self.broker.emit_after("worker_shutdown", self)
         self.logger.info("Worker has been shut down.")
 
-    def join(self):
+    def join(self) -> None:
         """Wait for this worker to complete its work in progress.
         This method is useful when testing code.
         """
@@ -182,7 +182,7 @@ class Worker:
                     continue
                 return
 
-    def _add_consumer(self, queue_name, *, delay=False):
+    def _add_consumer(self, queue_name: str, *, delay: bool = False) -> None:
         if queue_name in self.consumers:
             self.logger.debug("A consumer for queue %r is already running.", queue_name)
             return
@@ -201,7 +201,7 @@ class Worker:
         )
         consumer.start()
 
-    def _add_worker(self):
+    def _add_worker(self) -> None:
         worker = _WorkerThread(
             broker=self.broker,
             consumers=self.consumers,
@@ -213,7 +213,7 @@ class Worker:
 
 
 class _WorkerMiddleware(Middleware):
-    def __init__(self, worker):
+    def __init__(self, worker: Worker):
         self.logger = get_logger(__name__, type(self))
         self.worker = worker
 
@@ -242,7 +242,7 @@ class _ConsumerThread(Thread):
         self.worker_timeout = worker_timeout
         self.delay_queue = PriorityQueue()
 
-    def run(self):
+    def run(self) -> None:
         self.logger.debug("Running consumer thread...")
         self.running = True
         self.broker.emit_after("consumer_thread_boot", self)
@@ -292,7 +292,7 @@ class _ConsumerThread(Thread):
         self.broker.emit_before("consumer_thread_shutdown", self)
         self.logger.debug("Consumer thread stopped.")
 
-    def handle_delayed_messages(self):
+    def handle_delayed_messages(self) -> None:
         """Enqueue any delayed messages whose eta has passed."""
         for eta, message in iter_queue(self.delay_queue):
             if eta > current_millis():
@@ -391,17 +391,17 @@ class _ConsumerThread(Thread):
         """
         self.consumer.requeue(messages)
 
-    def pause(self):
+    def pause(self) -> None:
         """Pause this consumer."""
         self.paused = True
         self.paused_event.clear()
 
-    def resume(self):
+    def resume(self) -> None:
         """Resume this consumer."""
         self.paused = False
         self.paused_event.clear()
 
-    def stop(self):
+    def stop(self) -> None:
         """Initiate the ConsumerThread shutdown sequence.
 
         Code calling this method should then join on the thread and
@@ -410,7 +410,7 @@ class _ConsumerThread(Thread):
         self.logger.debug("Stopping consumer thread...")
         self.running = False
 
-    def close(self):
+    def close(self) -> None:
         """Close this consumer thread and its underlying connection."""
         try:
             if self.consumer:
@@ -443,7 +443,7 @@ class _WorkerThread(Thread):
         self.work_queue = work_queue
         self.timeout = worker_timeout / 1000
 
-    def run(self):
+    def run(self) -> None:
         self.logger.debug("Running worker thread...")
         self.running = True
         self.broker.emit_after("worker_thread_boot", self)
@@ -536,17 +536,17 @@ class _WorkerThread(Thread):
             # while before a GC triggers.
             message.clear_exception()
 
-    def pause(self):
+    def pause(self) -> None:
         """Pause this worker."""
         self.paused = True
         self.paused_event.clear()
 
-    def resume(self):
+    def resume(self) -> None:
         """Resume this worker."""
         self.paused = False
         self.paused_event.clear()
 
-    def stop(self):
+    def stop(self) -> None:
         """Initiate the WorkerThread shutdown process.
 
         Code calling this method should then join on the thread and

--- a/examples/issue_351/app.py
+++ b/examples/issue_351/app.py
@@ -3,7 +3,7 @@ import dramatiq
 
 @dramatiq.actor
 def foo():
-    a = tuple(range(5000000))  # noqa
+    a = tuple(range(5000000))  # noqa: F841
     raise Exception("bar")
 
 


### PR DESCRIPTION
Closes #727

Adds a bunch of type annotations to many public functions; in two cases the annotations would require a minor rewrite of code itself.

I’ve not annotated `message` arguments because they can be either of type `Message` or `MessageProxy` (because they’re used interchangeably). I also refrained from importing modules guarded by `if TYPE_CHECKING` but I can add that too and further improve some method signatures. Please let me know what you prefer!