### PR TITLE
Use `from __future__ import annotations` everywhere

### DIFF
--- a/dramatiq/__init__.py
+++ b/dramatiq/__init__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .actor import Actor, actor
 from .broker import Broker, Consumer, MessageProxy, get_broker, set_broker
 from .composition import group, pipeline

--- a/dramatiq/__main__.py
+++ b/dramatiq/__main__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import sys
 
 from dramatiq.cli import main

--- a/dramatiq/asyncio.py
+++ b/dramatiq/asyncio.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import asyncio
 import concurrent.futures
 import functools
@@ -36,7 +38,7 @@ R = TypeVar("R")
 _event_loop_thread = None
 
 
-def get_event_loop_thread() -> Optional["EventLoopThread"]:
+def get_event_loop_thread() -> Optional[EventLoopThread]:
     """Get the global event loop thread.
 
     Returns:
@@ -45,7 +47,7 @@ def get_event_loop_thread() -> Optional["EventLoopThread"]:
     return _event_loop_thread
 
 
-def set_event_loop_thread(thread: Optional["EventLoopThread"]) -> None:
+def set_event_loop_thread(thread: Optional[EventLoopThread]) -> None:
     """Set the global event loop thread."""
     global _event_loop_thread
     _event_loop_thread = thread

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 import os
 import time

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import glob
 import random
 import time

--- a/dramatiq/brokers/stub.py
+++ b/dramatiq/brokers/stub.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import time
 from collections import defaultdict
 from itertools import chain

--- a/dramatiq/canteen.py
+++ b/dramatiq/canteen.py
@@ -15,9 +15,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 # Don't depend on *anything* in this module.  The contents of this
 # module can and *will* change without notice.
-
 import time
 from contextlib import contextmanager
 from ctypes import Array, Structure, c_bool, c_byte, c_int

--- a/dramatiq/cli.py
+++ b/dramatiq/cli.py
@@ -15,9 +15,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 # Don't depend on *anything* in this module.  The contents of this
 # module can and *will* change without notice.
-
 import argparse
 import atexit
 import functools

--- a/dramatiq/common.py
+++ b/dramatiq/common.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import threading
 from os import getenv
 from queue import Empty

--- a/dramatiq/compat.py
+++ b/dramatiq/compat.py
@@ -15,9 +15,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 # Don't depend on *anything* in this module.  The contents of this
 # module can and *will* change without notice.
-
 import sys
 from contextlib import contextmanager
 

--- a/dramatiq/encoder.py
+++ b/dramatiq/encoder.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import abc
 import json
 import pickle

--- a/dramatiq/errors.py
+++ b/dramatiq/errors.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from typing import Optional
 
 

--- a/dramatiq/generic.py
+++ b/dramatiq/generic.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from . import actor
 
 

--- a/dramatiq/logging.py
+++ b/dramatiq/logging.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import inspect
 import logging
 

--- a/dramatiq/message.py
+++ b/dramatiq/message.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import dataclasses
 import time
 import uuid
@@ -101,7 +103,7 @@ class Message(Generic[R]):
         return result
 
     @classmethod
-    def decode(cls, data: bytes) -> "Message":
+    def decode(cls, data: bytes) -> Message:
         """Convert a bytestring to a message.
 
         Raises:
@@ -119,7 +121,7 @@ class Message(Generic[R]):
         """Convert this message to a bytestring."""
         return global_encoder.encode(self.asdict())
 
-    def copy(self, **attributes) -> "Message":
+    def copy(self, **attributes) -> Message:
         """Create a copy of this message."""
         new_options = attributes.pop("options", {})
         return dataclasses.replace(self, **attributes, options={**self.options, **new_options})
@@ -171,7 +173,7 @@ class Message(Generic[R]):
 
         return "%s(%s)" % (self.actor_name, params)
 
-    def __lt__(self, other: "Message") -> bool:
+    def __lt__(self, other: Message) -> bool:
         return dataclasses.astuple(self) < dataclasses.astuple(other)
 
     # Backwards-compatibility with namedtuple.
@@ -185,5 +187,5 @@ class Message(Generic[R]):
     def _fields(self) -> tuple[str, ...]:
         return tuple(f.name for f in dataclasses.fields(self))
 
-    def _replace(self, **changes) -> "Message[R]":
+    def _replace(self, **changes) -> Message[R]:
         return dataclasses.replace(self, **changes)

--- a/dramatiq/middleware/__init__.py
+++ b/dramatiq/middleware/__init__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .age_limit import AgeLimit
 from .asyncio import AsyncIO
 from .callbacks import Callbacks

--- a/dramatiq/middleware/age_limit.py
+++ b/dramatiq/middleware/age_limit.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from ..common import current_millis
 from ..logging import get_logger
 from .middleware import Middleware, SkipMessage

--- a/dramatiq/middleware/callbacks.py
+++ b/dramatiq/middleware/callbacks.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .middleware import Middleware
 
 

--- a/dramatiq/middleware/current_message.py
+++ b/dramatiq/middleware/current_message.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import contextvars
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -40,10 +42,10 @@ class CurrentMessage(Middleware):
 
     """
 
-    _MESSAGE: contextvars.ContextVar["Optional[Message[Any]]"] = contextvars.ContextVar("_MESSAGE", default=None)
+    _MESSAGE: contextvars.ContextVar[Optional[Message[Any]]] = contextvars.ContextVar("_MESSAGE", default=None)
 
     @classmethod
-    def get_current_message(cls) -> "Optional[Message[Any]]":
+    def get_current_message(cls) -> Optional[Message[Any]]:
         """Get the message that triggered the current actor.  Messages
         are thread local so this returns ``None`` when called outside
         of actor code.

--- a/dramatiq/middleware/group_callbacks.py
+++ b/dramatiq/middleware/group_callbacks.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import os
 
 from ..rate_limits import Barrier

--- a/dramatiq/middleware/middleware.py
+++ b/dramatiq/middleware/middleware.py
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
+
 class MiddlewareError(Exception):
     """Base class for middleware errors."""
 

--- a/dramatiq/middleware/pipelines.py
+++ b/dramatiq/middleware/pipelines.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .middleware import Middleware
 
 

--- a/dramatiq/middleware/prometheus.py
+++ b/dramatiq/middleware/prometheus.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import os
 import tempfile
 from http.server import BaseHTTPRequestHandler, HTTPServer

--- a/dramatiq/middleware/retries.py
+++ b/dramatiq/middleware/retries.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import time
 import traceback
 

--- a/dramatiq/middleware/shutdown.py
+++ b/dramatiq/middleware/shutdown.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import threading
 import warnings
 from typing import Optional, Type

--- a/dramatiq/middleware/threading.py
+++ b/dramatiq/middleware/threading.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from ..threading import (
     Interrupt,
     current_platform,

--- a/dramatiq/middleware/time_limit.py
+++ b/dramatiq/middleware/time_limit.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import threading
 import warnings
 from threading import Thread

--- a/dramatiq/rate_limits/__init__.py
+++ b/dramatiq/rate_limits/__init__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .backend import RateLimiterBackend
 from .barrier import Barrier
 from .bucket import BucketRateLimiter

--- a/dramatiq/rate_limits/backend.py
+++ b/dramatiq/rate_limits/backend.py
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
+
 class RateLimiterBackend:
     """ABC for rate limiter backends."""
 

--- a/dramatiq/rate_limits/backends/__init__.py
+++ b/dramatiq/rate_limits/backends/__init__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import warnings
 
 from .stub import StubBackend

--- a/dramatiq/rate_limits/backends/memcached.py
+++ b/dramatiq/rate_limits/backends/memcached.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from pylibmc import Client, ClientPool, NotFound
 
 from ..backend import RateLimiterBackend

--- a/dramatiq/rate_limits/backends/redis.py
+++ b/dramatiq/rate_limits/backends/redis.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import redis
 
 from ..backend import RateLimiterBackend

--- a/dramatiq/rate_limits/backends/stub.py
+++ b/dramatiq/rate_limits/backends/stub.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import time
 from collections import defaultdict
 from threading import Condition, Lock

--- a/dramatiq/rate_limits/barrier.py
+++ b/dramatiq/rate_limits/barrier.py
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
+
 class Barrier:
     """A distributed barrier.
 

--- a/dramatiq/rate_limits/bucket.py
+++ b/dramatiq/rate_limits/bucket.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import time
 
 from .rate_limiter import RateLimiter

--- a/dramatiq/rate_limits/concurrent.py
+++ b/dramatiq/rate_limits/concurrent.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .rate_limiter import RateLimiter
 
 

--- a/dramatiq/rate_limits/rate_limiter.py
+++ b/dramatiq/rate_limits/rate_limiter.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 
 from ..errors import RateLimitExceeded

--- a/dramatiq/rate_limits/window.py
+++ b/dramatiq/rate_limits/window.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import time
 
 from .rate_limiter import RateLimiter

--- a/dramatiq/results/__init__.py
+++ b/dramatiq/results/__init__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .backend import Missing, ResultBackend
 from .errors import ResultError, ResultFailure, ResultMissing, ResultTimeout
 from .middleware import Results

--- a/dramatiq/results/backend.py
+++ b/dramatiq/results/backend.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import hashlib
 import time
 import typing

--- a/dramatiq/results/backends/__init__.py
+++ b/dramatiq/results/backends/__init__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import warnings
 
 from .stub import StubBackend

--- a/dramatiq/results/backends/memcached.py
+++ b/dramatiq/results/backends/memcached.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from pylibmc import Client, ClientPool
 
 from ..backend import Missing, ResultBackend

--- a/dramatiq/results/backends/redis.py
+++ b/dramatiq/results/backends/redis.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import redis
 
 from ..backend import DEFAULT_TIMEOUT, ResultBackend, ResultMissing, ResultTimeout

--- a/dramatiq/results/backends/stub.py
+++ b/dramatiq/results/backends/stub.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import time
 from typing import Optional
 

--- a/dramatiq/results/errors.py
+++ b/dramatiq/results/errors.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from ..errors import DramatiqError
 
 

--- a/dramatiq/results/middleware.py
+++ b/dramatiq/results/middleware.py
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 from ..errors import ActorNotFound
 from ..logging import get_logger
 from ..middleware import Middleware

--- a/dramatiq/results/result.py
+++ b/dramatiq/results/result.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .errors import ResultFailure
 
 # We need to deal with backwards-compatibility here in case the user

--- a/dramatiq/threading.py
+++ b/dramatiq/threading.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import ctypes
 import inspect
 import platform

--- a/dramatiq/watcher.py
+++ b/dramatiq/watcher.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import signal

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import os
 import time
 from collections import defaultdict
@@ -91,7 +93,7 @@ class Worker:
         # workers as those messages could have far-future etas.
         self.delay_prefetch = DELAY_QUEUE_PREFETCH or min(worker_threads * 1000, 65535)
 
-        self.workers: list["_WorkerThread"] = []
+        self.workers: list[_WorkerThread] = []
         self.work_queue: PriorityQueue[tuple[int, MessageProxy]] = PriorityQueue()
         self.worker_timeout = worker_timeout
         self.worker_threads = worker_threads
@@ -111,7 +113,7 @@ class Worker:
 
     def pause(self) -> None:
         """Pauses all the worker threads."""
-        child: Union["_WorkerThread", "_ConsumerThread"]
+        child: Union[_WorkerThread, _ConsumerThread]
 
         for child in self.consumers.values():
             child.pause()
@@ -125,7 +127,7 @@ class Worker:
 
     def resume(self) -> None:
         """Resumes all the worker threads."""
-        child: Union["_WorkerThread", "_ConsumerThread"]
+        child: Union[_WorkerThread, _ConsumerThread]
 
         for child in self.consumers.values():
             child.resume()
@@ -143,7 +145,7 @@ class Worker:
         self.broker.emit_before("worker_shutdown", self)
         self.logger.info("Shutting down...")
 
-        thread: Union["_WorkerThread", "_ConsumerThread"]
+        thread: Union[_WorkerThread, _ConsumerThread]
 
         # Stop workers before consumers.  The consumers are kept alive
         # during this process so that heartbeats keep being sent to

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,5 @@ known_first_party = dramatiq
 multi_line_output = 5
 order_by_type = true
 profile = black
+# Remove annotations import once we only support python 3.14+
+add_imports = from __future__ import annotations

--- a/tests/benchmarks/test_rabbitmq_cli.py
+++ b/tests/benchmarks/test_rabbitmq_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import time
 

--- a/tests/benchmarks/test_redis_cli.py
+++ b/tests/benchmarks/test_redis_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import time
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 from contextlib import contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import random

--- a/tests/middleware/test_asyncio.py
+++ b/tests/middleware/test_asyncio.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import asyncio
 from threading import get_ident
 from unittest import mock
-from dramatiq import threading, actor
-from dramatiq.middleware import CurrentMessage
+
 import pytest
 
+from dramatiq import actor, threading
 from dramatiq.asyncio import (
     EventLoopThread,
     async_to_sync,
@@ -12,6 +14,7 @@ from dramatiq.asyncio import (
     set_event_loop_thread,
 )
 from dramatiq.logging import get_logger
+from dramatiq.middleware import CurrentMessage
 from dramatiq.middleware.asyncio import AsyncIO
 
 from ..common import worker

--- a/tests/middleware/test_prometheus.py
+++ b/tests/middleware/test_prometheus.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 import urllib.request as request
 from threading import Thread

--- a/tests/middleware/test_retries.py
+++ b/tests/middleware/test_retries.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import time
 from unittest.mock import patch

--- a/tests/middleware/test_shutdown.py
+++ b/tests/middleware/test_shutdown.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 from unittest import mock

--- a/tests/middleware/test_threading.py
+++ b/tests/middleware/test_threading.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 from threading import Thread

--- a/tests/middleware/test_time_limit.py
+++ b/tests/middleware/test_time_limit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 from unittest import mock

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from datetime import timedelta
 from unittest.mock import patch

--- a/tests/test_barrier.py
+++ b/tests/test_barrier.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from concurrent.futures import ThreadPoolExecutor
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import logging
+
 import pytest
 
 import dramatiq

--- a/tests/test_bucket_rate_limiter.py
+++ b/tests/test_bucket_rate_limiter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from dramatiq.rate_limits import BucketRateLimiter

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import Counter
 
 import pytest

--- a/tests/test_canteen.py
+++ b/tests/test_canteen.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import multiprocessing
 
 import pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import signal
 import time

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from dramatiq.common import dq_name, q_name, xq_name

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from threading import Condition, Event
 

--- a/tests/test_concurrent_rate_limiter.py
+++ b/tests/test_concurrent_rate_limiter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from concurrent.futures import ThreadPoolExecutor
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import dramatiq

--- a/tests/test_generic_actors.py
+++ b/tests/test_generic_actors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 import pytest

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dramatiq
 
 

--- a/tests/test_pidfile.py
+++ b/tests/test_pidfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import signal
 import time

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import time
 from threading import Event
@@ -9,10 +11,10 @@ import pytest
 import dramatiq
 from dramatiq import Message, Middleware, QueueJoinTimeout, Worker
 from dramatiq.brokers.rabbitmq import (
+    MAX_DECLARE_ATTEMPTS,
     RabbitmqBroker,
     URLRabbitmqBroker,
     _IgnoreScaryLogs,
-    MAX_DECLARE_ATTEMPTS,
 )
 from dramatiq.common import current_millis
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from unittest import mock
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from unittest.mock import patch
 

--- a/tests/test_stub_broker.py
+++ b/tests/test_stub_broker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from unittest.mock import Mock
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from pathlib import Path
 

--- a/tests/test_window_rate_limiter.py
+++ b/tests/test_window_rate_limiter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .common import worker
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,5 +36,5 @@ extras =
 commands=
   black --line-length 120 --target-version py39 --check {toxinidir}/dramatiq {toxinidir}/examples {toxinidir}/tests
   flake8 {toxinidir}/dramatiq {toxinidir}/examples {toxinidir}/tests
-  isort -c {toxinidir}/dramatiq
+  isort -c {toxinidir}/dramatiq {toxinidir}/tests
   mypy {toxinidir}/dramatiq {toxinidir}/tests


### PR DESCRIPTION
* For consistency - was already used in some files
* So type hints shouldn't need to use string quotes
* Also make the `tests` directory be checked by isort in CI. (most imports there were already sorted)