### PR TITLE
Define the build backend used to build the project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools >= 80.9.0, < 81"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 120
 target-version = ["py39", "py310", "py311", "py312", "py313"]


### PR DESCRIPTION
For now, we are still using `setup.py` as the build configuration. Build frontends default to using setuptools when the build backend is not defined like this, so this is sort of redundant, but it is still good practice, and a first step to getting rid of `setup.py` (if we want to).

See PEP 517/518,
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/ 
https://packaging.python.org/en/latest/discussions/setup-py-deprecated/