### PR TITLE
Document before/after_enqueue signals as including retries

### DIFF
--- a/dramatiq/middleware/middleware.py
+++ b/dramatiq/middleware/middleware.py
@@ -90,10 +90,10 @@ class Middleware:
         """Called after a delay queue has been declared."""
 
     def before_enqueue(self, broker: Broker, message: Message, delay: int) -> None:
-        """Called before a message is enqueued."""
+        """Called before a message is enqueued (including retries)."""
 
     def after_enqueue(self, broker: Broker, message: Message, delay: int) -> None:
-        """Called after a message has been enqueued."""
+        """Called after a message has been enqueued (including retries)."""
 
     def before_delay_message(self, broker: Broker, message: MessageProxy) -> None:
         """Called before a message has been delayed in worker memory."""


### PR DESCRIPTION
Retry middleware code re-enqueueing the task: https://github.com/Bogdanp/dramatiq/blob/9037687d7c1ca1970acab525424f788fb24256fa/dramatiq/middleware/retries.py#L148

Brokers sending events:

https://github.com/Bogdanp/dramatiq/blob/9037687d7c1ca1970acab525424f788fb24256fa/dramatiq/brokers/redis.py#L193-L195

https://github.com/Bogdanp/dramatiq/blob/9037687d7c1ca1970acab525424f788fb24256fa/dramatiq/brokers/stub.py#L113-L115

https://github.com/Bogdanp/dramatiq/blob/9037687d7c1ca1970acab525424f788fb24256fa/dramatiq/brokers/rabbitmq.py#L365-L375