### PR TITLE
Fix edge case raising exception in `StubBroker.join()`

### DIFF
--- a/dramatiq/brokers/stub.py
+++ b/dramatiq/brokers/stub.py
@@ -173,7 +173,7 @@ class StubBroker(Broker):
             else:
                 if fail_fast:
                     for message in self.dead_letters_by_queue[queue_name]:
-                        raise message._exception from None
+                        raise (message._exception or Exception("Message failed with unknown error")) from None
 
                 return
 

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -353,13 +353,14 @@ class _ConsumerThread(Thread):
                 actor = self.broker.get_actor(message.actor_name)
                 self.logger.debug("Pushing message %r onto work queue.", message.message_id)
                 self.work_queue.put((actor.priority, message))
-        except ActorNotFound:
+        except ActorNotFound as e:
             self.logger.error(
                 "Received message for undefined actor %r. Moving it to the DLQ.",
                 message.actor_name,
                 exc_info=True,
             )
             message.fail()
+            message.stuff_exception(e)
             self.post_process_message(message)
 
     def post_process_message(self, message: MessageProxy) -> None:

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -8,7 +8,7 @@ import pytest
 
 import dramatiq
 from dramatiq import Message, Middleware
-from dramatiq.errors import RateLimitExceeded
+from dramatiq.errors import ActorNotFound, RateLimitExceeded
 from dramatiq.middleware import CurrentMessage, SkipMessage
 
 from .common import skip_on_pypy, worker
@@ -315,7 +315,8 @@ def test_messages_belonging_to_missing_actors_are_rejected(stub_broker, stub_wor
     stub_broker.enqueue(message)
 
     # Then join on the queue
-    stub_broker.join("some-queue")
+    with pytest.raises(ActorNotFound, match=r"^some-actor$"):
+        stub_broker.join("some-queue", fail_fast=True)
     stub_worker.join()
 
     # I expect the message to end up on the dead letter queue


### PR DESCRIPTION
I found this issue while working on #758

In `StubBroker.join()` when `message._exception` is None, we should fallback to an Exception.
This prevents errors like:
`TypeError: exceptions must derive from BaseException`
Either way an exception is raised, but this way it is an Exception with a nice message,
rather than TypeError.

Also fixes when Consumer handling a message gets `ActorNotFound` exception, store the Exception in the MessageProxy.

This means the exception is available to the `after_nack` middleware hook.
And available to the StubBroker to raise, when calling `.join(fail_fast=True)`