### PR TITLE
add dramatiq_worker_timeout environment variable

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -73,3 +73,4 @@ of those changes to CLEARTYPE SRL.
 | [@guedesfelipe](https://github.com/guedesfelipe)       | Felipe Guedes          |
 | [@karolinepauls](https://karolinepauls.com)            | Karoline Pauls         |
 | [@gurelkaynak](https://gurel.kaynak.link)              | Gurel Kaynak           |
+| [@ksoviero-zengrc](https://github.com/ksoviero-zengrc) | Kevin Soviero          |

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -271,3 +271,6 @@ These are the environment variables that dramatiq reads
    * - ``dramatiq_prom_port``
      - 9191
      - See :ref:`prometheus-metrics`.
+   * - ``dramatiq_worker_timeout``
+     - 1000
+     - The number of milliseconds workers should wake up after if the queue is idle.

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -53,6 +53,9 @@ QUEUE_PREFETCH = int(os.getenv("dramatiq_queue_prefetch", 0))
 #: prefetched.
 DELAY_QUEUE_PREFETCH = int(os.getenv("dramatiq_delay_queue_prefetch", 0))
 
+#: The number of milliseconds workers should wake up after if the queue is idle.
+WORKER_TIMEOUT = int(os.getenv("worker_timeout", 1000))
+
 
 class Worker:
     """Workers consume messages off of all declared queues and
@@ -77,7 +80,7 @@ class Worker:
         broker: Broker,
         *,
         queues: Optional[set[str]] = None,
-        worker_timeout: int = 1000,
+        worker_timeout: int = WORKER_TIMEOUT,
         worker_threads: int = 8,
     ) -> None:
         self.logger = get_logger(__name__, type(self))

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -54,7 +54,7 @@ QUEUE_PREFETCH = int(os.getenv("dramatiq_queue_prefetch", 0))
 DELAY_QUEUE_PREFETCH = int(os.getenv("dramatiq_delay_queue_prefetch", 0))
 
 #: The number of milliseconds workers should wake up after if the queue is idle.
-WORKER_TIMEOUT = int(os.getenv("worker_timeout", 1000))
+WORKER_TIMEOUT = int(os.getenv("dramatiq_worker_timeout", 1000))
 
 
 class Worker:


### PR DESCRIPTION
This PR allows specifying the `dramatiq_worker_timeout` as an environment variable which is then passed into the worker. The goal for us was to be able to increase the `max_backoff` setting in `compute_backoff` with Redis because the default of 1000ms is too low for our use case. 