### PR TITLE
Remove URLRabbitmqBroker. 

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -54,6 +54,9 @@ Minor Breaking Changes
 
 These are changes that while technically breaking, we believe are unlikely to effect your project.
 
+* Removed ``URLRabbitmqBroker``. This has been deprecated since version 1.1.0.
+  Use |RabbitmqBroker| with ``url`` as a keyword argument instead.
+  (`#786`_, `@LincolnPuzey`_)
 * Removed the ``dev`` installable extra from the project metadata.
   Instead the development dependencies are defined in a `PEP-735`_
   ``[dependency-groups]`` table in ``pyproject.toml``.
@@ -81,6 +84,7 @@ These are changes that while technically breaking, we believe are unlikely to ef
 .. _#772: https://github.com/Bogdanp/dramatiq/pull/772
 .. _#782: https://github.com/Bogdanp/dramatiq/pull/782
 .. _@mikeroll: https://github.com/mikeroll
+.. _#786: https://github.com/Bogdanp/dramatiq/pull/786
 
 Fixed
 ^^^^^
@@ -1092,8 +1096,8 @@ Changed
 Deprecated
 ^^^^^^^^^^
 
-* |URLRabbitmqBroker| is deprecated.  The |RabbitmqBroker| takes a
-  ``url`` parameter so use that instead.  |URLRabbitmqBroker| will be
+* ``URLRabbitmqBroker`` is deprecated.  The |RabbitmqBroker| takes a
+  ``url`` parameter so use that instead.  ``URLRabbitmqBroker`` will be
   removed in version 2.0.
 
 Fixed
@@ -1372,7 +1376,7 @@ Changed
 ^^^^^^^
 
 * Consumer reconnect backoff factor has been lowered from 10s to 100ms.
-* |URLRabbitmqBroker| is now a factory function that creates instances
+* ``URLRabbitmqBroker`` is now a factory function that creates instances
   of |RabbitmqBroker|.
 
 Fixed
@@ -1412,7 +1416,7 @@ Fixed
 Added
 ^^^^^
 
-* |URLRabbitmqbroker| (`@whalesalad`_).
+* ``URLRabbitmqbroker`` (`@whalesalad`_).
 * StubBroker |StubBroker_flush| and |StubBroker_flush_all|.
 * |before_consumer_thread_shutdown| middleware hook.
 * |before_worker_thread_shutdown| middleware hook.

--- a/docs/source/global.rst
+++ b/docs/source/global.rst
@@ -41,7 +41,6 @@
 .. |StubBroker| replace:: :class:`StubBroker<dramatiq.brokers.stub.StubBroker>`
 .. |TimeLimitExceeded| replace:: :class:`TimeLimitExceeded<dramatiq.middleware.TimeLimitExceeded>`
 .. |TimeLimit| replace:: :class:`TimeLimit<dramatiq.middleware.TimeLimit>`
-.. |URLRabbitmqBroker| replace:: :class:`URLRabbitmqBroker<dramatiq.brokers.rabbitmq.URLRabbitmqBroker>`
 .. |WindowRateLimiter| replace:: :class:`WindowRateLimiter<dramatiq.rate_limits.WindowRateLimiter>`
 .. |Worker_join| replace:: :meth:`Worker.join<dramatiq.Worker.join>`
 .. |Worker_pause| replace:: :meth:`Worker.pause<dramatiq.Worker.pause>`

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import logging
 import os
 import time
-import warnings
 from functools import partial
 from itertools import chain
 from threading import Event, local
@@ -496,23 +495,6 @@ class RabbitmqBroker(Broker):
                 successes = 0
 
             self.connection.sleep(idle_time / 1000)
-
-
-def URLRabbitmqBroker(url: str, *, middleware: Optional[list[Middleware]] = None):
-    """Alias for the RabbitMQ broker that takes a connection URL as a
-    positional argument.
-
-    Parameters:
-      url(str): A connection string.
-      middleware(list[Middleware]): The middleware to add to this
-        broker.
-    """
-    warnings.warn(
-        "Use RabbitmqBroker with the 'url' parameter instead of URLRabbitmqBroker.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return RabbitmqBroker(url=url, middleware=middleware)
 
 
 class _IgnoreScaryLogs(logging.Filter):

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -14,7 +14,6 @@ from dramatiq import Message, Middleware, QueueJoinTimeout, Worker
 from dramatiq.brokers.rabbitmq import (
     MAX_DECLARE_ATTEMPTS,
     RabbitmqBroker,
-    URLRabbitmqBroker,
     _IgnoreScaryLogs,
 )
 from dramatiq.common import current_millis
@@ -25,18 +24,6 @@ from .common import (
     RABBITMQ_USERNAME,
     skip_unless_rabbit_mq,
 )
-
-
-def test_urlrabbitmq_creates_instances_of_rabbitmq_broker():
-    # Given a URL connection string
-    url = "amqp://%s:%s@127.0.0.1:5672" % (RABBITMQ_USERNAME, RABBITMQ_PASSWORD)
-
-    # When I pass that to URLRabbitmqBroker
-    with pytest.warns(DeprecationWarning):
-        broker = URLRabbitmqBroker(url)
-
-    # Then I should get back a RabbitmqBroker
-    assert isinstance(broker, RabbitmqBroker)
 
 
 @skip_unless_rabbit_mq


### PR DESCRIPTION
This has been deprecated since version 1.1.0.