### PR TITLE
Remove usage of watchdog_gevent compatibility library

### DIFF
--- a/dramatiq/watcher.py
+++ b/dramatiq/watcher.py
@@ -7,13 +7,6 @@ import signal
 import watchdog.events
 import watchdog.observers.polling
 
-try:
-    import watchdog_gevent
-
-    EVENTED_OBSERVER = watchdog_gevent.Observer
-except ImportError:
-    EVENTED_OBSERVER = watchdog.observers.Observer
-
 
 def setup_file_watcher(path, use_polling=False, include_patterns=None, exclude_patterns=None):
     """Sets up a background thread that watches for source changes and
@@ -23,7 +16,7 @@ def setup_file_watcher(path, use_polling=False, include_patterns=None, exclude_p
     if use_polling:
         observer_class = watchdog.observers.polling.PollingObserver
     else:
-        observer_class = EVENTED_OBSERVER
+        observer_class = watchdog.observers.Observer
 
     if include_patterns is None:
         include_patterns = ["*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,5 @@ module = [
     "pylibmc",
     "redis",
     "watchdog",
-    "watchdog_gevent",
 ]
 ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ with open(rel("dramatiq", "__init__.py"), "r") as f:
 
 extra_dependencies = {
     "gevent": [
-        "gevent>=1.1",
+        "gevent>=25.9.1",
     ],
     "memcached": [
         "pylibmc>=1.5,<2.0",
@@ -58,8 +58,7 @@ extra_dependencies = {
         "redis>=4.0,<7.0",
     ],
     "watch": [
-        "watchdog>=4.0",
-        "watchdog_gevent>=0.2",
+        "watchdog>=6.0.0",
     ],
 }
 


### PR DESCRIPTION
The latest watchdog+gevent seems to work together with no extra changes (https://github.com/gorakhargosh/watchdog/issues/306). Bump dramatiq's required versions of them to latest.