### PR TITLE
Fix AsyncIO middleware keeping local references in traceback

### DIFF
--- a/dramatiq/middleware/asyncio.py
+++ b/dramatiq/middleware/asyncio.py
@@ -38,3 +38,7 @@ class AsyncIO(Middleware):
         event_loop_thread.stop()
         event_loop_thread.join()
         set_event_loop_thread(None)
+
+    def after_process_message(self, broker, message, *, result=None, exception=None):
+        if exception is not None:
+            exception.__traceback__ = None


### PR DESCRIPTION
## Problem 

While investigating a memory leak in [polar](https://github.com/polarsource/polar), we found out that exceptions raised inside async actors lead to local references being held until worker shutdown.

When a coroutine raises an exception:
1. The asyncio `Future` captures the exception with its full traceback
2. The traceback holds references to all frame locals (database connections, HTTP clients, large data structures, etc.)
3. These references are never cleared, causing memory to accumulate over time


<details>
<summary>Demo script showing the issue</summary>

```py
import os
import time

import dramatiq
import psutil
from dramatiq.brokers.redis import RedisBroker
from dramatiq.middleware.asyncio import AsyncIO

broker = RedisBroker(url="redis://localhost:6379/0")
dramatiq.set_broker(broker)
broker.add_middleware(AsyncIO())


class BigException(Exception):
    def __init__(self, a: bytes) -> None:
        self.a = a
        super().__init__("Big exception")


MEMORY_LOG_FILE = "memory_usage.csv"


def log_memory(label: str = "") -> None:
    process = psutil.Process()
    memory_info = process.memory_info()
    timestamp = time.time()
    memory_mb = memory_info.rss / 1024 / 1024

    file_exists = os.path.exists(MEMORY_LOG_FILE)
    with open(MEMORY_LOG_FILE, "a") as f:
        if not file_exists:
            f.write("timestamp,memory_mb,label\n")
        f.write(f"{timestamp},{memory_mb:.2f},{label}\n")


@dramatiq.actor(actor_name="oom_task", max_retries=1_000_000, max_backoff=100)
async def oom_task() -> None:
    log_memory("before_alloc")
    a = bytes(bytearray(128 * 1024 * 1024))
    log_memory("after_alloc")
    raise BigException(a)


if __name__ == "__main__":
    oom_task.send()
```
</details>

## Fix

Added an `after_process_message` hook to the `AsyncIO` middleware that clears `exception.__traceback__`. This runs after the worker logs the exception (so stack traces are preserved for debugging) but before references can accumulate.

