### PR TITLE
Make docs build fail on warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = --fail-on-warning
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = dramatiq
 SOURCEDIR     = source


### PR DESCRIPTION
This will ensure the CI job fails when there is problems with the docs