### PR TITLE
Update pytest/coverage config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,11 @@ docs = [
 
 [tool.pytest.ini_options]
 testpaths = "tests"
-addopts = "--cov dramatiq --cov-report html --benchmark-autosave --benchmark-compare"
+addopts = "--cov=dramatiq --cov=tests --cov-report=term --no-cov-on-fail"
+
+[tool.coverage.run]
+branch = true
+source = ['dramatiq', 'tests']
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Do not save and compare benchmarks by default. Most of the time this is not required.
This fixes an issue preventing running tests through the pycharm UI.

Benchmark tests are still skipped in CI, but run by default locally.

Measure coverage of both dramatiq and tests dirs
Generate terminal report by default instead of html, so it is visible in CI output.
Enable branch coverage
Don't show console report if tests fail.