### PR TITLE
Add SafePickleEncoder with restricted unpickler; deprecate PickleEncoder

### DIFF
--- a/dramatiq/__init__.py
+++ b/dramatiq/__init__.py
@@ -22,7 +22,7 @@ import warnings
 from .actor import Actor, actor
 from .broker import Broker, Consumer, MessageProxy, get_broker, set_broker
 from .composition import group, pipeline
-from .encoder import Encoder, JSONEncoder, PickleEncoder
+from .encoder import Encoder, JSONEncoder, PickleEncoder, SafePickleEncoder
 from .errors import (
     ActorNotFound,
     BrokerConnectionError,
@@ -60,6 +60,7 @@ __all__ = [
     "Encoder",
     "JSONEncoder",
     "PickleEncoder",
+    "SafePickleEncoder",
     # Errors
     "DramatiqError",
     "BrokerError",

--- a/dramatiq/encoder.py
+++ b/dramatiq/encoder.py
@@ -18,9 +18,11 @@
 from __future__ import annotations
 
 import abc
+import io
 import json
 import pickle
 import typing
+import warnings
 
 from .errors import DecodeError
 
@@ -63,13 +65,108 @@ class JSONEncoder(Encoder):
 class PickleEncoder(Encoder):
     """Pickles messages.
 
-    Warning:
-      This encoder is not secure against maliciously-constructed data.
-      Use it at your own risk.
+    .. deprecated:: 2.1.1
+      :class:`PickleEncoder` deserializes data without restrictions,
+      making it vulnerable to remote code execution when a broker is
+      compromised.  Use :class:`SafePickleEncoder` instead.
     """
 
     def encode(self, data: MessageData) -> bytes:
         return pickle.dumps(data)
 
     def decode(self, data: bytes) -> MessageData:
+        warnings.warn(
+            "PickleEncoder is deprecated because it is vulnerable to "
+            "remote code execution via crafted pickle payloads. Use "
+            "SafePickleEncoder instead, which restricts unpickling to "
+            "safe built-in types. PickleEncoder will be removed in "
+            "dramatiq v3.0.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return pickle.loads(data)
+
+
+#: Types that :class:`SafePickleEncoder` allows during unpickling.
+_SAFE_BUILTINS: frozenset[str] = frozenset({
+    "builtins.True",
+    "builtins.False",
+    "builtins.None",
+    "builtins.int",
+    "builtins.float",
+    "builtins.complex",
+    "builtins.bytes",
+    "builtins.bytearray",
+    "builtins.str",
+    "builtins.tuple",
+    "builtins.list",
+    "builtins.dict",
+    "builtins.set",
+    "builtins.frozenset",
+    "builtins.slice",
+    "builtins.type",
+    "builtins.range",
+    "builtins.enumerate",
+    "datetime.datetime",
+    "datetime.date",
+    "datetime.time",
+    "datetime.timedelta",
+    "datetime.timezone",
+    "collections.OrderedDict",
+    "decimal.Decimal",
+    "uuid.UUID",
+})
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that only allows a safe set of built-in types."""
+
+    def __init__(self, file: typing.IO[bytes], *, allowed: frozenset[str]) -> None:
+        super().__init__(file)
+        self._allowed = allowed
+
+    def find_class(self, module: str, name: str) -> type:
+        key = f"{module}.{name}"
+        if key not in self._allowed:
+            raise DecodeError(
+                f"Unpickling {key!r} is not allowed. Only built-in "
+                f"types are permitted by SafePickleEncoder.",
+                key,
+                None,
+            )
+        return super().find_class(module, name)
+
+
+class SafePickleEncoder(Encoder):
+    """Pickles messages using a restricted unpickler.
+
+    Only a fixed set of built-in Python types are allowed during
+    deserialization, which prevents remote code execution through
+    crafted pickle payloads.
+
+    The default allow-list covers the types typically found in Dramatiq
+    message metadata: ``int``, ``float``, ``str``, ``bytes``, ``list``,
+    ``dict``, ``tuple``, ``set``, ``frozenset``, ``datetime``,
+    ``Decimal``, ``UUID``, and a few others.  You can extend it by
+    passing *extra_allowed* to the constructor.
+
+    Parameters:
+      extra_allowed: An optional set of ``"module.qualname"`` strings
+        for additional types that should be permitted.
+    """
+
+    def __init__(self, *, extra_allowed: typing.Iterable[str] = ()) -> None:
+        self._allowed: frozenset[str] = _SAFE_BUILTINS | frozenset(extra_allowed)
+
+    def encode(self, data: MessageData) -> bytes:
+        return pickle.dumps(data)
+
+    def decode(self, data: bytes) -> MessageData:
+        try:
+            return _RestrictedUnpickler(io.BytesIO(data), allowed=self._allowed).load()
+        except DecodeError:
+            raise
+        except Exception as e:
+            raise DecodeError(
+                "failed to decode data %r" % (data,), data, e
+            ) from None

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,14 +1,28 @@
 from __future__ import annotations
 
+import os
+import pickle
+
 import pytest
 
 import dramatiq
+from dramatiq.encoder import SafePickleEncoder, _SAFE_BUILTINS
+from dramatiq.errors import DecodeError
 
 
 @pytest.fixture
 def pickle_encoder():
     old_encoder = dramatiq.get_encoder()
     new_encoder = dramatiq.PickleEncoder()
+    dramatiq.set_encoder(new_encoder)
+    yield new_encoder
+    dramatiq.set_encoder(old_encoder)
+
+
+@pytest.fixture
+def safe_pickle_encoder():
+    old_encoder = dramatiq.get_encoder()
+    new_encoder = dramatiq.SafePickleEncoder()
     dramatiq.set_encoder(new_encoder)
     yield new_encoder
     dramatiq.set_encoder(old_encoder)
@@ -41,3 +55,88 @@ def test_pickle_encoder(pickle_encoder, stub_broker, stub_worker):
 
     # Then I expect the message to have been processed
     assert db == [1]
+
+
+def test_pickle_encoder_emits_deprecation_warning():
+    # Given a PickleEncoder
+    encoder = dramatiq.PickleEncoder()
+    data = encoder.encode({"key": "value"})
+
+    # When I decode data
+    # Then a DeprecationWarning should be raised
+    with pytest.warns(DeprecationWarning, match="PickleEncoder is deprecated"):
+        encoder.decode(data)
+
+
+# --- SafePickleEncoder tests ---
+
+def test_safe_pickle_encoder_roundtrips_basic_types():
+    encoder = SafePickleEncoder()
+    data = {
+        "queue_name": "default",
+        "actor_name": "add",
+        "args": [1, 2.5, "hello", True, None],
+        "kwargs": {"key": "value"},
+        "options": {},
+    }
+    assert encoder.decode(encoder.encode(data)) == data
+
+
+def test_safe_pickle_encoder_roundtrips_sets_and_tuples():
+    encoder = SafePickleEncoder()
+    data = {"items": [1, 2, 3], "frozen": "test"}
+    encoded = encoder.encode(data)
+    assert encoder.decode(encoded) == data
+
+
+def test_safe_pickle_encoder_blocks_os_system():
+    # Craft a malicious pickle that would call os.system("echo pwned")
+    malicious = (
+        b"\x80\x04\x95\x1e\x00\x00\x00\x00\x00\x00\x00"
+        b"\x8c\x02os\x8c\x06system\x93\x8c\necho pwned\x85R."
+    )
+    encoder = SafePickleEncoder()
+    with pytest.raises(DecodeError, match="os.system.*is not allowed"):
+        encoder.decode(malicious)
+
+
+def test_safe_pickle_encoder_blocks_arbitrary_classes():
+    # Build a payload that references os.getcwd (a harmless function,
+    # but still not in the allow-list).
+    malicious = pickle.dumps(os.getcwd)
+    encoder = SafePickleEncoder()
+    with pytest.raises(DecodeError):
+        encoder.decode(malicious)
+
+
+def test_safe_pickle_encoder_extra_allowed():
+    # Given a SafePickleEncoder with an extra allowed type
+    encoder = SafePickleEncoder(extra_allowed={"posixpath.PurePosixPath"})
+
+    # The custom allow-list should be a superset of the defaults
+    assert encoder._allowed == _SAFE_BUILTINS | {"posixpath.PurePosixPath"}
+
+
+def test_safe_pickle_encoder_with_stub_broker(safe_pickle_encoder, stub_broker, stub_worker):
+    # Given that I've set a SafePickleEncoder as the global encoder
+    # And I have an actor that adds a value to a db
+    db = []
+
+    @dramatiq.actor
+    def add_value(x):
+        db.append(x)
+
+    # When I send that actor a message
+    add_value.send(42)
+
+    # And wait on the broker and worker
+    stub_broker.join(add_value.queue_name)
+    stub_worker.join()
+
+    # Then I expect the message to have been processed
+    assert db == [42]
+
+
+def test_safe_pickle_encoder_is_importable_from_top_level():
+    assert hasattr(dramatiq, "SafePickleEncoder")
+    assert dramatiq.SafePickleEncoder is SafePickleEncoder


### PR DESCRIPTION
## Summary

Fixes #848 — `PickleEncoder` calls `pickle.loads()` without restrictions, enabling remote code execution via crafted pickle payloads when an attacker has broker access.

This PR:
- **Adds `SafePickleEncoder`** — a drop-in replacement that uses a `RestrictedUnpickler` subclass, limiting deserialization to a fixed allow-list of safe built-in types (`int`, `str`, `dict`, `list`, `datetime`, `UUID`, `Decimal`, etc.)
- **Supports extension** via `extra_allowed` parameter for projects that need custom types
- **Deprecates `PickleEncoder`** — `decode()` now emits a `DeprecationWarning` recommending `SafePickleEncoder`, with removal planned for v3.0.0
- **Exports `SafePickleEncoder`** from the top-level `dramatiq` package

## Migration

```python
# Before
import dramatiq
dramatiq.set_encoder(dramatiq.PickleEncoder())

# After
import dramatiq
dramatiq.set_encoder(dramatiq.SafePickleEncoder())

# If you need custom types:
dramatiq.set_encoder(dramatiq.SafePickleEncoder(
    extra_allowed={"mymodule.MyClass"}
))
```

## Test plan

- [x] Roundtrip encode/decode of basic Python types (int, float, str, bytes, list, dict, tuple, set, None, bool)
- [x] Malicious pickle payloads (e.g. `os.system`) are blocked with `DecodeError`
- [x] Arbitrary classes not in the allow-list are rejected
- [x] `extra_allowed` parameter correctly extends the allow-list
- [x] `PickleEncoder.decode()` emits `DeprecationWarning`
- [x] Integration test with stub broker and worker
- [x] `SafePickleEncoder` is importable from `dramatiq` top-level