### PR TITLE
Fix Redis delayed message promotion

### DIFF
--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -364,6 +364,18 @@ class Consumer:
           messages(Iterable[MessageProxy]): The messages to requeue.
         """
 
+    def enqueue_from_delay_queue(self, message: MessageProxy) -> bool | None:
+        """Atomically move a delayed message to its canonical queue if
+        this consumer supports it.
+
+        Returns:
+          True: When the delayed message was moved.
+          False: When the operation was supported but the message was no
+            longer owned by this consumer.
+          None: When the operation is not supported.
+        """
+        return None
+
     def __next__(self) -> MessageProxy | None:  # pragma: no cover
         """Retrieve the next message off of the queue.
 

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -28,7 +28,7 @@ from uuid import uuid4
 import redis
 
 from ..broker import Broker, Consumer, MessageProxy
-from ..common import compute_backoff, current_millis, dq_name, getenv_int
+from ..common import compute_backoff, current_millis, dq_name, getenv_int, q_name
 from ..errors import ConnectionClosed, QueueJoinTimeout
 from ..logging import get_logger
 from ..message import Message
@@ -330,6 +330,21 @@ class _RedisConsumer(Consumer):
 
         self.logger.debug("Re-enqueueing %r on queue %r.", message_ids, self.queue_name)
         self.broker.do_requeue(self.queue_name, *message_ids)
+
+    def enqueue_from_delay_queue(self, message):
+        new_message = message.copy(queue_name=q_name(message.queue_name))
+        del new_message.options["eta"]
+
+        try:
+            return bool(
+                self.broker.do_enqueue_delayed(
+                    self.queue_name,
+                    message.options["redis_message_id"],
+                    new_message.encode(),
+                )
+            )
+        except redis.ConnectionError as e:
+            raise ConnectionClosed(e) from None
 
     def __next__(self):
         try:

--- a/dramatiq/brokers/redis/dispatch.lua
+++ b/dramatiq/brokers/redis/dispatch.lua
@@ -187,6 +187,26 @@ elseif command == "requeue" then
     end
 
 
+-- Atomically moves a due delayed message from its delay queue ack group
+-- to the canonical queue.
+elseif command == "enqueue_delayed" then
+    local message_id = ARGS[1]
+    local message_data = ARGS[2]
+
+    if redis.call("srem", queue_acks, message_id) > 0 then
+        if redis.call("hdel", queue_messages, message_id) > 0 then
+            local target_queue_full_name = namespace .. ":" .. queue_canonical_name
+            local target_queue_messages = target_queue_full_name .. ".msgs"
+
+            redis.call("hset", target_queue_messages, message_id, message_data)
+            redis.call("rpush", target_queue_full_name, message_id)
+            return 1
+        end
+    end
+
+    return 0
+
+
 -- Acknowledges that a message has been processed.
 elseif command == "ack" then
     local message_id = ARGS[1]

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -337,8 +337,10 @@ class ConsumerThread(Thread):
             new_message = message.copy(queue_name=queue_name)
             del new_message.options["eta"]
 
-            self.broker.enqueue(new_message)
-            self.post_process_message(message)
+            promoted = self.consumer.enqueue_from_delay_queue(message) if self.consumer else None
+            if promoted is None:
+                self.broker.enqueue(new_message)
+                self.post_process_message(message)
             self.delay_queue.task_done()
 
     def handle_message(self, message: MessageProxy) -> None:

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -8,7 +8,8 @@ import redis
 
 import dramatiq
 from dramatiq import Message, QueueJoinTimeout
-from dramatiq.brokers.redis import MAINTENANCE_SCALE, RedisBroker
+from dramatiq.broker import MessageProxy
+from dramatiq.brokers.redis import MAINTENANCE_SCALE, RedisBroker, _RedisConsumer
 from dramatiq.common import current_millis, dq_name, xq_name
 from dramatiq.errors import BrokerConnectionError
 
@@ -278,6 +279,43 @@ def test_redis_requeues_unhandled_delay_messages_on_shutdown(redis_broker):
     # I expect it to have re-enqueued the message
     messages = redis_broker.client.lrange("dramatiq:%s" % dq_name(do_work.queue_name), 0, 10)
     assert message.options["redis_message_id"].encode("utf-8") in messages
+
+
+def test_redis_consumer_promotes_delayed_messages_atomically():
+    # Given that I have a Redis consumer with a delayed message
+    class Broker:
+        def __init__(self):
+            self.promoted_messages = []
+
+        def do_enqueue_delayed(self, queue_name, redis_message_id, message_data):
+            self.promoted_messages.append((queue_name, redis_message_id, Message.decode(message_data)))
+            return 1
+
+    broker = Broker()
+    consumer = _RedisConsumer(broker, "default.DQ", prefetch=1, timeout=100)
+    message = MessageProxy(
+        Message(
+            queue_name="default.DQ",
+            actor_name="actor",
+            args=(),
+            kwargs={},
+            options={"eta": 0, "redis_message_id": "redis-message-id"},
+        )
+    )
+
+    # When I promote that delayed message
+    promoted = consumer.enqueue_from_delay_queue(message)
+
+    # Then the broker moves the existing Redis message id into the
+    # canonical queue with eta stripped from the payload.
+    assert promoted
+    assert len(broker.promoted_messages) == 1
+
+    queue_name, redis_message_id, promoted_message = broker.promoted_messages[0]
+    assert queue_name == "default.DQ"
+    assert redis_message_id == "redis-message-id"
+    assert promoted_message.queue_name == "default"
+    assert promoted_message.options == {"redis_message_id": "redis-message-id"}
 
 
 def test_redis_broker_can_join_with_timeout(redis_broker, redis_worker):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+from queue import PriorityQueue
+
+from dramatiq.broker import MessageProxy
+from dramatiq.message import Message
+from dramatiq.worker import ConsumerThread
+
 from .common import worker
 
 
@@ -13,3 +19,51 @@ def test_workers_dont_register_queues_that_arent_whitelisted(stub_broker):
         # Then a consumer should not get spun up for that queue
         assert "c" not in stub_worker.consumers
         assert "c.DQ" not in stub_worker.consumers
+
+
+def test_delayed_messages_use_consumer_promotion_hook():
+    # Given that I have a consumer that can atomically promote delayed messages
+    class Broker:
+        def __init__(self):
+            self.enqueued_messages = []
+
+        def enqueue(self, message):
+            self.enqueued_messages.append(message)
+
+    class Consumer:
+        def __init__(self):
+            self.promoted_messages = []
+
+        def enqueue_from_delay_queue(self, message):
+            self.promoted_messages.append(message)
+            return True
+
+    broker = Broker()
+    consumer = Consumer()
+    consumer_thread = ConsumerThread(
+        broker=broker,
+        queue_name="default.DQ",
+        prefetch=1,
+        work_queue=PriorityQueue(),
+        worker_timeout=100,
+    )
+    consumer_thread.consumer = consumer
+
+    message = MessageProxy(
+        Message(
+            queue_name="default.DQ",
+            actor_name="actor",
+            args=(),
+            kwargs={},
+            options={"eta": 0, "redis_message_id": "redis-message-id"},
+        )
+    )
+    consumer_thread.delay_queue.put((0, message))
+
+    # When delayed messages are handled
+    consumer_thread.handle_delayed_messages()
+
+    # Then the consumer-specific promotion hook should be used instead of
+    # a generic enqueue followed by a separate ack.
+    assert consumer.promoted_messages == [message]
+    assert broker.enqueued_messages == []


### PR DESCRIPTION
Fixes https://github.com/Bogdanp/dramatiq/issues/431.

Redis delayed messages were promoted by enqueueing a copy to the canonical queue and then acking the original delay-queue message as two separate operations. If the original delay message was requeued before the ack completed, the same logical message could be promoted more than once.

This PR adds a Redis-specific consumer hook that promotes due delayed messages atomically in the Redis Lua dispatch script. The generic worker path still falls back to the existing enqueue-then-ack behavior for consumers that do not implement the hook.

Verification:
- `.venv/bin/python -m pytest tests/test_worker.py::test_delayed_messages_use_consumer_promotion_hook tests/test_redis.py::test_redis_consumer_promotes_delayed_messages_atomically -q`
- `.venv/bin/python -m pytest tests/test_redis.py tests/test_worker.py -q` with Redis 7 running locally via Docker: `23 passed in 66.07s`
- `.venv/bin/python -m black --check dramatiq/broker.py dramatiq/worker.py dramatiq/brokers/redis.py tests/test_worker.py tests/test_redis.py`
- `.venv/bin/python -m isort -c dramatiq/broker.py dramatiq/worker.py dramatiq/brokers/redis.py tests/test_worker.py tests/test_redis.py`
- `.venv/bin/python -m flake8 dramatiq/broker.py dramatiq/worker.py dramatiq/brokers/redis.py tests/test_worker.py tests/test_redis.py`
- `.venv/bin/python -m mypy dramatiq/broker.py dramatiq/worker.py dramatiq/brokers/redis.py tests/test_worker.py tests/test_redis.py`
- Standalone fakeredis smoke check for the new Lua command.