### PR TITLE
Don't run release workflow in forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   package:
     runs-on: ubuntu-latest
 
+    # Don't run in forks in the unlikely event a Release is created there.
+    if: github.repository == 'Bogdanp/dramatiq'
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
Don't run release workflow in forks in the unlikely event a Release is created there.

[skip ci]