### PR TITLE
Sort messages in Worker's in-memory `work_queue` by queued time, not just priority.

### DIFF
--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, Iterable, Optional, cast
 
 from .errors import ActorNotFound
@@ -425,9 +426,11 @@ class MessageProxy:
         return f"<{self.__class__.__qualname__} {self._message!r}>"
 
     def __lt__(self, other) -> bool:
-        # This can get called if two messages have the same priority
-        # in a queue.  If that's the case, we don't care which runs
-        # first.
+        warnings.warn(
+            "Comparing MessageProxy instances by order (>, <, etc) is deprecated and will be removed in dramatiq v3.0.0.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return True
 
     def __eq__(self, other) -> bool:

--- a/dramatiq/brokers/stub.py
+++ b/dramatiq/brokers/stub.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from collections import defaultdict
 from itertools import chain
@@ -68,6 +69,7 @@ class StubBroker(Broker):
             return _StubConsumer(
                 self.queues[queue_name],
                 self.dead_letters_by_queue[queue_name],
+                prefetch,
                 timeout,
             )
         except KeyError:
@@ -195,24 +197,36 @@ class StubBroker(Broker):
 
 
 class _StubConsumer(Consumer):
-    def __init__(self, queue, dead_letters, timeout):
+    def __init__(self, queue, dead_letters, prefetch, timeout):
         self.queue = queue
         self.dead_letters = dead_letters
+        self.prefetch = prefetch
         self.timeout = timeout
+
+        # Use a Semaphore to manage 'slots' for prefetched messages.
+        self.prefetch_semaphore = threading.Semaphore(value=prefetch)
 
     def ack(self, message):
         self.queue.task_done()
+        self.prefetch_semaphore.release()
 
     def nack(self, message):
         self.queue.task_done()
         self.dead_letters.append(message)
+        self.prefetch_semaphore.release()
 
     def __next__(self):
+        # Reserve a prefetch 'slot' for the message being fetched.
+        if not self.prefetch_semaphore.acquire(timeout=self.timeout / 1000):
+            return None  # No slot available, return None
+
         try:
             data = self.queue.get(timeout=self.timeout / 1000)
             message = Message.decode(data)
             return _StubMessageProxy(message)
         except Empty:
+            # No message available, release 'slot' that was reserved.
+            self.prefetch_semaphore.release()
             return None
 
 

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import os
 import time
 from collections import defaultdict
@@ -97,7 +98,7 @@ class Worker:
         self.delay_prefetch = DELAY_QUEUE_PREFETCH or min(worker_threads * 1000, 65535)
 
         self.workers: list[WorkerThread] = []
-        self.work_queue: PriorityQueue[tuple[int, MessageProxy]] = PriorityQueue()
+        self.work_queue: PriorityQueue[_WorkQueueItem] = PriorityQueue()
         self.worker_timeout = worker_timeout
         self.worker_threads = worker_threads
 
@@ -168,8 +169,8 @@ class Worker:
 
         self.logger.debug("Requeueing in-memory messages...")
         messages_by_queue = defaultdict(list)
-        for _, message in iter_queue(self.work_queue):
-            messages_by_queue[message.queue_name].append(message)
+        for item in iter_queue(self.work_queue):
+            messages_by_queue[item.message.queue_name].append(item.message)
 
         for queue_name, messages in messages_by_queue.items():
             try:
@@ -251,6 +252,23 @@ class _WorkerMiddleware(Middleware):
         self.worker._add_consumer(queue_name, delay=True)
 
 
+@dataclasses.dataclass(frozen=True, slots=True, eq=True, order=True)
+class _WorkQueueItem:
+    """This class is used as wrapper around MessageProxy when they are placed in a PriorityQueue.
+
+    It uses order=True to define __lt__ etc., so the "lowest" item will be first in the queue.
+    The lowest item is the one with the lowest priority, or lowest _queued_time if priority matches.
+    Note the message itself is not compared.
+
+    The intention of this is to make the PriorityQueue operate in a roughly FIFO manner for items with equal priority.
+    """
+
+    # The priority of the message on the queue. This is either actor.priority, or options.eta for delayed messages.
+    priority: int
+    message: MessageProxy = dataclasses.field(compare=False)
+    _queued_time: int = dataclasses.field(default_factory=time.monotonic_ns)
+
+
 class ConsumerThread(Thread):
     def __init__(
         self,
@@ -258,7 +276,7 @@ class ConsumerThread(Thread):
         broker: Broker,
         queue_name: str,
         prefetch: int,
-        work_queue: PriorityQueue[tuple[int, MessageProxy]],
+        work_queue: PriorityQueue[_WorkQueueItem],
         worker_timeout: int,
     ) -> None:
         super().__init__(daemon=True)
@@ -273,7 +291,7 @@ class ConsumerThread(Thread):
         self.queue_name = queue_name
         self.work_queue = work_queue
         self.worker_timeout = worker_timeout
-        self.delay_queue: PriorityQueue[tuple[int, MessageProxy]] = PriorityQueue()
+        self.delay_queue: PriorityQueue[_WorkQueueItem] = PriorityQueue()
 
     def run(self) -> None:
         self.logger.debug("Running consumer thread...")
@@ -327,9 +345,11 @@ class ConsumerThread(Thread):
 
     def handle_delayed_messages(self) -> None:
         """Enqueue any delayed messages whose eta has passed."""
-        for eta, message in iter_queue(self.delay_queue):
+        for item in iter_queue(self.delay_queue):
+            eta = item.priority
+            message = item.message
             if eta > current_millis():
-                self.delay_queue.put((eta, message))
+                self.delay_queue.put(item)
                 self.delay_queue.task_done()
                 break
 
@@ -361,12 +381,12 @@ class ConsumerThread(Thread):
             if "eta" in message.options:
                 self.logger.debug("Pushing message %r onto delay queue.", message.message_id)
                 self.broker.emit_before("delay_message", message)
-                self.delay_queue.put((message.options.get("eta", 0), message))
+                self.delay_queue.put(_WorkQueueItem(message.options.get("eta", 0), message))
 
             else:
                 actor = self.broker.get_actor(message.actor_name)
                 self.logger.debug("Pushing message %r onto work queue.", message.message_id)
-                self.work_queue.put((actor.priority, message))
+                self.work_queue.put(_WorkQueueItem(actor.priority, message))
         except ActorNotFound as e:
             self.logger.error(
                 "Received message for undefined actor %r. Moving it to the DLQ.",
@@ -463,7 +483,7 @@ class ConsumerThread(Thread):
         """Close this consumer thread and its underlying connection."""
         try:
             if self.consumer:
-                self.requeue_messages(m for _, m in iter_queue(self.delay_queue))
+                self.requeue_messages(item.message for item in iter_queue(self.delay_queue))
                 self.consumer.close()
         except BrokerConnectionError:
             pass
@@ -476,7 +496,7 @@ class WorkerThread(Thread):
     Parameters:
       broker(Broker)
       consumers(dict[str, ConsumerThread])
-      work_queue(Queue)
+      work_queue(PriorityQueue[_WorkQueueItem])
       worker_timeout(int)
     """
 
@@ -485,7 +505,7 @@ class WorkerThread(Thread):
         *,
         broker: Broker,
         consumers: dict[str, ConsumerThread],
-        work_queue: PriorityQueue[tuple[int, MessageProxy]],
+        work_queue: PriorityQueue[_WorkQueueItem],
         worker_timeout: int,
     ) -> None:
         super().__init__(daemon=True)
@@ -511,8 +531,8 @@ class WorkerThread(Thread):
                 continue
 
             try:
-                _, message = self.work_queue.get(timeout=self.timeout)
-                self.process_message(message)
+                item = self.work_queue.get(timeout=self.timeout)
+                self.process_message(item.message)
             except Empty:
                 continue
 

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 import dramatiq
+import dramatiq.worker
 from dramatiq import Message, Middleware
 from dramatiq.errors import ActorNotFound, RateLimitExceeded
 from dramatiq.middleware import CurrentMessage, SkipMessage, TimeLimitExceeded
@@ -424,7 +425,11 @@ def test_workers_can_be_paused(stub_broker, stub_worker):
 
 
 def test_actors_can_prioritize_work(stub_broker):
-    with worker(stub_broker, worker_timeout=100, worker_threads=1) as stub_worker:
+    with (
+        # Increase prefetch so all messages are prefetched onto work_queue
+        patch.object(dramatiq.worker, "QUEUE_PREFETCH", 20),
+        worker(stub_broker, worker_timeout=100, worker_threads=1) as stub_worker,
+    ):
         # Given that I a paused worker
         stub_worker.pause()
 

--- a/tests/test_stub_broker.py
+++ b/tests/test_stub_broker.py
@@ -111,3 +111,30 @@ def test_stub_broker_flush_all_does_not_break_dead_letters(stub_broker, stub_wor
     do_work.send()
     with pytest.raises(SomeError):
         stub_broker.join(do_work.queue_name)
+
+
+def test_stub_broker_respects_prefetch(stub_broker, stub_worker):
+    """Test that the stub broker respect the prefetch option."""
+
+    # Adjust Worker to only prefetch 5 messages
+    stub_worker.queue_prefetch = 5
+
+    @dramatiq.actor()
+    def do_work():
+        pass
+
+    # Pause just worker threads (not consumers) so messages are not removed from worker.work_queue
+    for worker_thread in stub_worker.workers:
+        worker_thread.pause()
+        worker_thread.paused_event.wait()
+
+    # Put 15 messages on the queue
+    for _ in range(15):
+        do_work.send()
+
+    time.sleep(0.01)
+
+    # 5 messages will be prefetched and should be on the work_queue
+    assert stub_worker.work_queue.qsize() == 5
+    # 10 messages will be left on the broker queue.
+    assert stub_broker.queues[do_work.queue_name].qsize() == 10

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import time
+
+import dramatiq
+import dramatiq.worker
+
 from .common import worker
 
 
@@ -13,3 +18,102 @@ def test_workers_dont_register_queues_that_arent_whitelisted(stub_broker):
         # Then a consumer should not get spun up for that queue
         assert "c" not in stub_worker.consumers
         assert "c.DQ" not in stub_worker.consumers
+
+
+def test_workers_process_messages_in_order(stub_broker) -> None:
+    """When worker is running with only one thread, messages are processed in order.
+
+    This is effectively testing messages are pulled from work_queue in a FIFO order."""
+
+    results = []
+
+    @dramatiq.actor()
+    def _do_work(value):
+        results.append(value)
+
+    try:
+        # Worker with one worker, but prefetches 10 messages
+        stub_worker = dramatiq.worker.Worker(stub_broker, worker_threads=1)
+        stub_worker.queue_prefetch = 10
+        stub_worker.start()
+
+        # Pause just worker threads (not consumers) so messages are not removed from worker.work_queue
+        for worker_thread in stub_worker.workers:
+            worker_thread.pause()
+            worker_thread.paused_event.wait()
+
+        # Put 5 messages on the queue
+        for i in range(5):
+            _do_work.send(i)
+            time.sleep(0.001)
+
+        # Check work_queue has 5 messages
+        assert stub_worker.work_queue.qsize() == 5
+
+        # Resume worker so messages are processed from work_queue
+        stub_worker.resume()
+        stub_broker.join(queue_name=_do_work.queue_name)
+    finally:
+        stub_worker.stop()
+
+    # Check messages were processed in order, i.e. messages came off work_queue in FIFO order.
+    assert results == [0, 1, 2, 3, 4]
+
+
+def test_queue_item_order():
+    """Test ordering of the _WorkQueueItem class.
+
+    This is important since this class is used with PriorityQueue.
+    """
+
+    @dramatiq.actor()
+    def do_work():
+        pass
+
+    message1 = do_work.message()
+    message2 = do_work.message()
+
+    message_proxy1 = dramatiq.MessageProxy(message1)
+    message_proxy2 = dramatiq.MessageProxy(message2)
+
+    # messages/items with different priorities,
+    message_1_item_priority_0 = dramatiq.worker._WorkQueueItem(priority=0, message=message_proxy1, _queued_time=0)
+    message_2_item_priority_1 = dramatiq.worker._WorkQueueItem(priority=1, message=message_proxy2, _queued_time=0)
+    assert message_1_item_priority_0 < message_2_item_priority_1
+    assert message_1_item_priority_0 <= message_2_item_priority_1
+    assert not message_1_item_priority_0 > message_2_item_priority_1
+    assert not message_1_item_priority_0 >= message_2_item_priority_1
+    assert message_1_item_priority_0 != message_2_item_priority_1
+    assert message_2_item_priority_1 > message_1_item_priority_0
+    assert message_2_item_priority_1 >= message_1_item_priority_0
+    assert not message_2_item_priority_1 < message_1_item_priority_0
+    assert not message_2_item_priority_1 <= message_1_item_priority_0
+    assert message_2_item_priority_1 != message_1_item_priority_0
+
+    # messages/items with same priority and different queue times,
+    message_1_item_time_0 = dramatiq.worker._WorkQueueItem(priority=0, message=message_proxy1, _queued_time=0)
+    message_2_item_time_1 = dramatiq.worker._WorkQueueItem(priority=0, message=message_proxy2, _queued_time=1)
+    assert message_1_item_time_0 < message_2_item_time_1
+    assert message_1_item_time_0 <= message_2_item_time_1
+    assert not message_1_item_time_0 > message_2_item_time_1
+    assert not message_1_item_time_0 >= message_2_item_time_1
+    assert message_1_item_time_0 != message_2_item_time_1
+    assert message_2_item_time_1 > message_1_item_time_0
+    assert message_2_item_time_1 >= message_1_item_time_0
+    assert not message_2_item_time_1 < message_1_item_time_0
+    assert not message_2_item_time_1 <= message_1_item_time_0
+    assert message_2_item_time_1 != message_1_item_time_0
+
+    # Messages/items with same priority and queue time
+    message_1_item_equal = dramatiq.worker._WorkQueueItem(priority=0, message=message_proxy1, _queued_time=0)
+    message_2_item_equal = dramatiq.worker._WorkQueueItem(priority=0, message=message_proxy2, _queued_time=0)
+    assert not message_1_item_equal < message_2_item_equal
+    assert not message_1_item_equal > message_2_item_equal
+    assert message_1_item_equal <= message_2_item_equal
+    assert message_1_item_equal >= message_2_item_equal
+    assert message_1_item_equal == message_2_item_equal
+    assert not message_2_item_equal < message_1_item_equal
+    assert not message_2_item_equal > message_1_item_equal
+    assert message_2_item_equal <= message_1_item_equal
+    assert message_2_item_equal >= message_1_item_equal
+    assert message_2_item_equal == message_1_item_equal


### PR DESCRIPTION
The Worker class uses the work_queue PriorityQueue to hold messages fetched from Brokers but not processed yet (i.e. prefetched messages).
Previously, this queue was only ordered by `actor.priority`, messages with the same `actor.priority`,
would be fetched from the Queue in an undefined order.

This could lead to messages being 'stuck' in the queue for some time, especially if other messages were constantly being added.

This commit fixes that by making the work_queue act in a roughly FIFO manner, by ordering messages by (actor.priority, _queued_time).
Where _queued_time is the time in nanoseconds when the message was put on the work_queue.

I say 'roughly' because some (most?) system clocks don't offer nanosecond precision.
Messages that get the same _queued_time will still have undefined order.
This is ok, the main goal is to prevent messages getting stuck.

Closes #850 

In order to test this properly, I also changed the StubBroker consumer to respect the prefetch option.