### PR TITLE
Fix Redis delayed message promotion race

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,3 +80,4 @@ of those changes to CLEARTYPE SRL.
 | [@ABolouk](https://github.com/ABolouk)                 | Amirhossein Bolouk Asli|
 | [@JoaoAlmeida20](https://github.com/JoaoAlmeida20)     | João Almeida           |
 | [@albcunha](https://github.com/albcunha)               | Alberto Cunha          |
+| [@BeamoINT](https://github.com/BeamoINT)               | BeamoINT               |

--- a/dramatiq/brokers/redis.py
+++ b/dramatiq/brokers/redis.py
@@ -185,6 +185,43 @@ class RedisBroker(Broker):
         self.emit_after("enqueue", message, delay)
         return message
 
+    def promote_delayed_message(self, message: MessageProxy, promoted_message: Message) -> bool:
+        """Atomically move a delayed message into its target queue.
+
+        Returns False if this broker no longer owns the delayed
+        message.  In that case, the message was likely requeued by
+        maintenance and should not be copied into the target queue.
+        """
+        message_id = message.options["redis_message_id"]
+
+        self.logger.debug(
+            "Promoting delayed message %r onto queue %r.", message.message_id, promoted_message.queue_name
+        )
+        self.emit_before("enqueue", promoted_message, None)
+        self.emit_before("ack", message)
+        try:
+            promoted = bool(
+                self.do_promote_delayed(
+                    message.queue_name,
+                    message_id,
+                    promoted_message.queue_name,
+                    promoted_message.encode(),
+                )
+            )
+        except redis.ConnectionError as e:
+            raise ConnectionClosed(e) from None
+
+        if promoted:
+            self.emit_after("enqueue", promoted_message, None)
+            self.emit_after("ack", message)
+        else:
+            self.logger.debug(
+                "Skipping delayed message %r because it is no longer owned by this consumer.",
+                message.message_id,
+            )
+
+        return promoted
+
     def get_declared_queues(self) -> set[str]:
         """Get all declared queues.
 
@@ -320,6 +357,12 @@ class _RedisConsumer(Consumer):
             self.broker.do_nack(self.queue_name, message.options["redis_message_id"])
         except redis.ConnectionError as e:
             raise ConnectionClosed(e) from None
+        finally:
+            self.queued_message_ids.discard(message.message_id)
+
+    def promote_delayed_message(self, message, promoted_message):
+        try:
+            return self.broker.promote_delayed_message(message, promoted_message)
         finally:
             self.queued_message_ids.discard(message.message_id)
 

--- a/dramatiq/brokers/redis/dispatch.lua
+++ b/dramatiq/brokers/redis/dispatch.lua
@@ -150,6 +150,25 @@ if command == "enqueue" then
     redis.call("rpush", queue_full_name, message_id)
 
 
+-- Atomically promotes a delayed message into its canonical queue.
+elseif command == "promote_delayed" then
+    local message_id = ARGS[1]
+    local target_queue_name = ARGS[2]
+    local message_data = ARGS[3]
+
+    if redis.call("srem", queue_acks, message_id) > 0 then
+        local target_queue_full_name = namespace .. ":" .. target_queue_name
+        local target_queue_messages = target_queue_full_name .. ".msgs"
+
+        redis.call("hdel", queue_messages, message_id)
+        redis.call("hset", target_queue_messages, message_id, message_data)
+        redis.call("rpush", target_queue_full_name, message_id)
+        return 1
+    end
+
+    return 0
+
+
 -- Returns up to $prefetch number of messages from $queue_full_name.
 elseif command == "fetch" then
     -- Ensure prefetch isn't so large that we get errors fetching

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -337,8 +337,12 @@ class ConsumerThread(Thread):
             new_message = message.copy(queue_name=queue_name)
             del new_message.options["eta"]
 
-            self.broker.enqueue(new_message)
-            self.post_process_message(message)
+            promote_delayed_message = getattr(self.consumer, "promote_delayed_message", None)
+            if promote_delayed_message is not None:
+                promote_delayed_message(message, new_message)
+            else:
+                self.broker.enqueue(new_message)
+                self.post_process_message(message)
             self.delay_queue.task_done()
 
     def handle_message(self, message: MessageProxy) -> None:

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -9,7 +9,7 @@ import redis
 import dramatiq
 from dramatiq import Message, QueueJoinTimeout
 from dramatiq.brokers.redis import MAINTENANCE_SCALE, RedisBroker
-from dramatiq.common import current_millis, dq_name, xq_name
+from dramatiq.common import current_millis, dq_name, q_name, xq_name
 from dramatiq.errors import BrokerConnectionError
 
 from .common import worker
@@ -133,6 +133,64 @@ def test_redis_actors_can_delay_messages_independent_of_each_other(redis_broker)
 
         # I expect the latter message to have been run first
         assert results == [2, 1]
+
+
+def test_redis_delayed_message_promotion_is_atomic(redis_broker):
+    # Given that I have an actor with a delayed message
+    @dramatiq.actor()
+    def do_work():
+        pass
+
+    message = do_work.send_with_options(delay=60000)
+    redis_message_id = message.options["redis_message_id"]
+    redis_message_id_bytes = redis_message_id.encode("utf-8")
+
+    # If I consume it off its delay queue
+    consumer = redis_broker.consume(dq_name(do_work.queue_name), prefetch=1, timeout=10)
+    delayed_message = next(consumer)
+    promoted_message = delayed_message.copy(queue_name=q_name(delayed_message.queue_name))
+    del promoted_message.options["eta"]
+
+    # And promote it into the canonical queue
+    assert consumer.promote_delayed_message(delayed_message, promoted_message)
+
+    # I expect the promotion to move the message without leaving the original delayed copy behind
+    assert consumer.outstanding_message_count == 0
+    assert redis_broker.client.lrange("dramatiq:%s" % do_work.queue_name, 0, 10) == [redis_message_id_bytes]
+    assert redis_broker.client.hget("dramatiq:%s.msgs" % dq_name(do_work.queue_name), redis_message_id) is None
+
+    stored_message = Message.decode(redis_broker.client.hget("dramatiq:%s.msgs" % do_work.queue_name, redis_message_id))
+    assert stored_message.options["redis_message_id"] == redis_message_id
+    assert "eta" not in stored_message.options
+
+
+def test_redis_delayed_message_promotion_skips_messages_lost_to_maintenance(redis_broker):
+    # Given that I have an actor with a delayed message
+    @dramatiq.actor()
+    def do_work():
+        pass
+
+    message = do_work.send_with_options(delay=60000)
+    redis_message_id = message.options["redis_message_id"]
+    redis_message_id_bytes = redis_message_id.encode("utf-8")
+    delay_queue_name = dq_name(do_work.queue_name)
+
+    # If I consume it off its delay queue
+    consumer = redis_broker.consume(delay_queue_name, prefetch=1, timeout=10)
+    delayed_message = next(consumer)
+
+    # But the message is requeued before promotion, like queue maintenance would do for a timed-out worker
+    redis_broker.do_requeue(delay_queue_name, redis_message_id)
+
+    promoted_message = delayed_message.copy(queue_name=q_name(delayed_message.queue_name))
+    del promoted_message.options["eta"]
+
+    # Then promotion should not create a duplicate in the canonical queue
+    assert not consumer.promote_delayed_message(delayed_message, promoted_message)
+    assert consumer.outstanding_message_count == 0
+    assert redis_broker.client.lrange("dramatiq:%s" % do_work.queue_name, 0, 10) == []
+    assert redis_broker.client.lrange("dramatiq:%s" % delay_queue_name, 0, 10) == [redis_message_id_bytes]
+    assert redis_broker.client.hget("dramatiq:%s.msgs" % delay_queue_name, redis_message_id) is not None
 
 
 def test_redis_unacked_messages_can_be_requeued(redis_broker):


### PR DESCRIPTION
## Summary

Fixes #431 by making Redis delayed-message promotion atomic.

A delayed Redis message was previously copied into the canonical queue before the original delay-queue message was acknowledged. If queue maintenance requeued the delayed original after the copy but before the ack completed, the same logical message could later be promoted again and processed more than once.

This change adds a Redis Lua command that only promotes a delayed message if the current consumer still owns its delay-queue ack. The command removes the delay-queue ack/hash entry and pushes the promoted message into the canonical queue in one Redis script. If ownership was already lost, promotion is skipped so another consumer can handle the requeued delayed message.

## Tests

- `git diff --check`
- `python3 -m compileall -q dramatiq tests/test_redis.py`
- `.venv/bin/python -m flake8 dramatiq/brokers/redis.py dramatiq/worker.py tests/test_redis.py`
- `.venv/bin/python -m black --target-version py310 --check dramatiq/brokers/redis.py dramatiq/worker.py tests/test_redis.py`
- `.venv/bin/python -m isort -c dramatiq/brokers/redis.py dramatiq/worker.py tests/test_redis.py`
- `.venv/bin/python -m pytest tests/test_redis.py --no-cov -q` with local Redis: `22 passed`
