### PR TITLE
Fix #862 -- Support redis-py 8.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ extra_dependencies = {
         "pika>=1.0,<2.0",
     ],
     "redis": [
-        "redis>=4.0,<8.0",
+        "redis>=4.0,<9.0",
     ],
     "watch": [
         "watchdog>=6.0.0",


### PR DESCRIPTION
I am following #826 here and just raising the upper border.

A full changelog of redis-py release:
https://github.com/redis/redis-py/releases/tag/v8.0.0