### PR TITLE
Harden release workflow by using seperate build/publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: PyPI release
 
+# Note this workflow is designed to be locked-down to prevent supply chain attacks;
+# 1. GitHub actions are specified by exact hash.
+# 2. Distributions are built in a seperate job to the publishing action.
+# 3. No caching is used to prevent cache poisoning.
+
 on:
   release:
     types: [ published ]
@@ -23,6 +28,21 @@ jobs:
       - name: Build dist packages
         run: python -m build .
 
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: "dist"
+          path: "dist/"
+
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'Bogdanp/dramatiq'
+    needs:
+      - package
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: "dist"
+          path: "dist"
       - name: Upload packages to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:


### PR DESCRIPTION
Split build+publish workflow into two jobs, I believe this is best practice so that the scope of any publishing token is limited, and build time does not have access to it.