### PR TITLE
Add feature for firing group completion callbacks on failure

### DIFF
--- a/dramatiq/middleware/group_callbacks.py
+++ b/dramatiq/middleware/group_callbacks.py
@@ -25,10 +25,44 @@ from .middleware import Middleware
 
 
 class GroupCallbacks(Middleware):
-    """Middleware that enables adding completion callbacks to |Groups|."""
+    """Middleware that enables adding completion callbacks to |Groups|.
 
-    def __init__(self, rate_limiter_backend: RateLimiterBackend, *, barrier_ttl: int = 86400 * 1000) -> None:
+    By default, completion callbacks are only fired when *all* tasks in
+    a group succeed.  Set ``fire_on_failure=True`` to also fire them when
+    the group finishes due to one or more tasks failing permanently
+    (i.e. after all retries are exhausted or the message is skipped).
+
+    Note: ``fire_on_failure`` requires the |Retries| middleware to be
+    active (so that ``message.failed`` is set on permanent failures) and
+    this middleware to run *after* it in the afte
+    r-phase.  Because the
+    after-phase runs middleware in reverse order, that means adding it
+    *before* |Retries| in the middleware list, e.g.::
+
+        broker.add_middleware(
+            GroupCallbacks(backend, fire_on_failure=True),
+            before=Retries,
+        )
+
+    Parameters:
+      rate_limiter_backend(RateLimiterBackend): The rate limiter backend
+        to use when creating group barriers.
+      barrier_ttl(int): The TTL, in milliseconds, for group barriers.
+        Defaults to 24 hours.
+      fire_on_failure(bool): Whether to fire completion callbacks even
+        when one or more tasks in the group have failed permanently.
+        Defaults to False to preserve backwards-compatible behaviour.
+    """
+
+    def __init__(
+        self,
+        rate_limiter_backend: RateLimiterBackend,
+        *,
+        barrier_ttl: int = 86400 * 1000,
+        fire_on_failure: bool = False,
+    ) -> None:
         self.rate_limiter_backend = rate_limiter_backend
+        self.fire_on_failure = fire_on_failure
 
         _barrier_ttl_env = os.getenv("dramatiq_group_callback_barrier_ttl", None)
         if _barrier_ttl_env is not None:
@@ -43,18 +77,32 @@ class GroupCallbacks(Middleware):
         else:
             self.barrier_ttl = barrier_ttl
 
-    def after_process_message(self, broker, message, *, result=None, exception=None):
+    def _try_fire_callbacks(self, broker, message):
         from ..message import Message
 
+        group_completion_uuid = message.options.get("group_completion_uuid")
+        group_completion_callbacks = message.options.get("group_completion_callbacks")
+        if group_completion_uuid and group_completion_callbacks:
+            barrier = Barrier(
+                self.rate_limiter_backend,
+                group_completion_uuid,
+                ttl=self.barrier_ttl,
+            )
+            if barrier.wait(block=False):
+                for callback_message in group_completion_callbacks:
+                    broker.enqueue(Message(**callback_message))
+
+    def after_process_message(self, broker, message, *, result=None, exception=None):
         if exception is None:
-            group_completion_uuid = message.options.get("group_completion_uuid")
-            group_completion_callbacks = message.options.get("group_completion_callbacks")
-            if group_completion_uuid and group_completion_callbacks:
-                barrier = Barrier(
-                    self.rate_limiter_backend,
-                    group_completion_uuid,
-                    ttl=self.barrier_ttl,
-                )
-                if barrier.wait(block=False):
-                    for message in group_completion_callbacks:
-                        broker.enqueue(Message(**message))
+            # Task succeeded -- always fire.
+            self._try_fire_callbacks(broker, message)
+        elif self.fire_on_failure and message.failed:
+            # Task failed permanently (retries exhausted) and the caller
+            # opted into failure callbacks -- fire.
+            self._try_fire_callbacks(broker, message)
+
+    def after_skip_message(self, broker, message):
+        if self.fire_on_failure:
+            # Skipped messages (e.g. AgeLimit) count as permanent
+            # failures when fire_on_failure is enabled.
+            self._try_fire_callbacks(broker, message)

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -507,3 +507,89 @@ def test_groups_of_pipelines_can_have_completion_callbacks(stub_broker, stub_wor
 
     # And the callback should run after all the messages
     assert sorted(do_nothing_times)[-1] <= finalize_times[0]
+
+
+def test_groups_do_not_fire_completion_callbacks_on_failure_by_default(stub_broker, stub_worker, rate_limiter_backend):
+    # Given that I've added the GroupCallbacks middleware to my broker
+    stub_broker.add_middleware(GroupCallbacks(rate_limiter_backend))
+
+    finalize_times = []
+
+    @dramatiq.actor(max_retries=0)
+    def fail():
+        raise RuntimeError("boom")
+
+    @dramatiq.actor
+    def finalize(n):
+        finalize_times.append(time.monotonic())
+
+    # When I group together some failing messages with a completion callback
+    g = group(fail.message() for _ in range(3))
+    g.add_completion_callback(finalize.message(42))
+    g.run()
+
+    stub_broker.join(fail.queue_name, fail_fast=False)
+    stub_worker.join()
+
+    # Then the callback should not run
+    assert len(finalize_times) == 0
+
+
+def test_groups_fire_completion_callbacks_on_failure_when_enabled(stub_broker, stub_worker, rate_limiter_backend):
+    # Given that I've added the GroupCallbacks middleware with fire_on_failure.
+    # It must run after Retries in the after-phase (i.e. before it in the
+    # middleware list) so that message.failed is set on permanent failures.
+    stub_broker.add_middleware(GroupCallbacks(rate_limiter_backend, fire_on_failure=True), before=middleware.Retries)
+
+    finalized = Event()
+    finalize_times = []
+
+    @dramatiq.actor(max_retries=0)
+    def maybe_fail(should_fail):
+        if should_fail:
+            raise RuntimeError("boom")
+
+    @dramatiq.actor
+    def finalize(n):
+        assert n == 42
+        finalize_times.append(time.monotonic())
+        finalized.set()
+
+    # When I group together some messages, one of which fails permanently
+    g = group([maybe_fail.message(True), maybe_fail.message(False), maybe_fail.message(False)])
+    g.add_completion_callback(finalize.message(42))
+    g.run()
+
+    # And wait for the callback to be called
+    finalized.wait(timeout=30)
+
+    # Then the callback should still run exactly once
+    assert len(finalize_times) == 1
+
+
+def test_groups_fire_completion_callbacks_on_skip_when_enabled(stub_broker, stub_worker, rate_limiter_backend):
+    # Given that I've added the GroupCallbacks middleware with fire_on_failure
+    stub_broker.add_middleware(GroupCallbacks(rate_limiter_backend, fire_on_failure=True))
+
+    finalized = Event()
+    finalize_times = []
+
+    @dramatiq.actor
+    def skip():
+        raise dramatiq.middleware.SkipMessage()
+
+    @dramatiq.actor
+    def finalize(n):
+        finalize_times.append(time.monotonic())
+        finalized.set()
+
+    # When I group together some messages, one of which is skipped
+    g = group([skip.message()])
+    g.add_completion_callback(finalize.message(42))
+    g.run()
+
+    # And wait for the callback to be called
+    finalized.wait(timeout=30)
+
+    # Then the callback should still run exactly once
+    assert len(finalize_times) == 1


### PR DESCRIPTION
`add_completion_callback` never fires if any task in the group fails permanently — the barrier just hangs forever. But a permanent failure is a completion; the group is done, just not successfully. The current behaviour is closer to `add_success_callback`.
Proposed fix: add `fire_on_failure=False` to `GroupCallbacks`. When `True`, the barrier is decremented on permanent failure (`message.failed`) and on skipped messages, firing the callbacks regardless of outcome. Defaults to `False` for backwards compatibility.
Prior art: `dramatiq-workflow` works around this externally via `message.failed` — the need is real.
Happy to submit a PR if this direction sounds good.