### PR TITLE
Add quorum queue support to RabbitmqBroker (queue_type flag) + delay-queue re-lease

### DIFF
--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -415,6 +415,58 @@ execution::
   rabbitmq_broker = RabbitmqBroker(host="rabbitmq")
   dramatiq.set_broker(rabbitmq_broker)
 
+Quorum Queue Broker
+^^^^^^^^^^^^^^^^^^^
+
+Pass ``queue_type="quorum"`` to the |RabbitmqBroker| to declare its
+queues as `quorum queues`_ instead of classic queues.  Quorum queues are
+replicated, always-durable FIFO queues and are the recommended queue type
+for most workloads.  This requires **RabbitMQ 4.3 or later**::
+
+  import dramatiq
+
+  from dramatiq.brokers.rabbitmq import RabbitmqBroker
+
+
+  rabbitmq_broker = RabbitmqBroker(host="rabbitmq", queue_type="quorum")
+  dramatiq.set_broker(rabbitmq_broker)
+
+This reuses all of the |RabbitmqBroker| machinery -- including the way
+delayed and retried messages are scheduled -- and only changes how the
+underlying queues are declared.  A few things differ from classic
+queues:
+
+- Message priorities work without any configuration.  Quorum queues
+  expose the full ``0``-``31`` strict priority range, so the
+  ``max_priority`` argument is not accepted; just send messages with the
+  ``broker_priority`` option.  Messages without an explicit priority
+  default to ``4``.
+- RabbitMQ's own poison-message handling (``x-delivery-limit``) is left
+  enabled on the main queue using the server default, unless you pass a
+  ``delivery_limit``.  It is always disabled on the delay queue.
+- The delivery-acknowledgement timeout for the *delay queue* is set
+  explicitly via the ``consumer_timeout`` argument, which defaults to
+  ``1_800_000`` (30 minutes, also the minimum).  Dramatiq sends it as the
+  ``x-consumer-timeout`` consumer argument on the delay-queue consumer
+  only -- the work queue is left to the server's own timeout, since those
+  messages are acked as soon as the actor finishes.
+
+Because dramatiq holds delayed and retried messages in memory until their
+scheduled time, a message delayed for longer than ``consumer_timeout``
+would otherwise be requeued by RabbitMQ before it runs.  To prevent this,
+the delay-queue consumer *re-leases* such a message -- re-enqueueing it
+before the timeout would elapse -- so its scheduled time is always
+honoured no matter how far in the future it is.  This is transparent: the
+message still runs exactly once, at its eta.
+
+.. note::
+
+   A queue that already exists as a classic queue cannot be redeclared
+   as a quorum queue.  When migrating an existing application, delete the
+   old queues (or use different queue names) before switching brokers.
+
+.. _quorum queues: https://www.rabbitmq.com/docs/quorum-queues
+
 Redis Broker
 ^^^^^^^^^^^^
 

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -42,6 +42,15 @@ DEAD_MESSAGE_TTL = int(os.getenv("dramatiq_dead_message_ttl", 86400000 * 7))
 MAX_ENQUEUE_ATTEMPTS = 6
 MAX_DECLARE_ATTEMPTS = 2
 
+#: The fraction of ``consumer_timeout`` after which the delay-queue
+#: consumer re-leases (re-enqueues) a still-waiting message, so its
+#: in-memory hold never approaches the broker's acknowledgement timeout.
+DELAY_QUEUE_LEASE_FACTOR = 0.75
+
+#: The smallest ``consumer_timeout`` (in milliseconds) Dramatiq accepts;
+#: 30 minutes, matching RabbitMQ's own default.
+MIN_CONSUMER_TIMEOUT = 1_800_000
+
 
 class RabbitmqBroker(Broker):
     """A broker that can be used with RabbitMQ.
@@ -94,8 +103,29 @@ class RabbitmqBroker(Broker):
         and connection parameters are provided, the URL is used.
       middleware(list[Middleware]): The set of middleware that apply
         to this broker.
+      queue_type(str): The type of queue to declare, either ``"classic"``
+        (the default) or ``"quorum"``.  Quorum queues are replicated,
+        always-durable FIFO queues and require **RabbitMQ 4.3+**.  They
+        always expose the full 0-31 strict priority range, so
+        ``max_priority`` is rejected; send with the ``broker_priority``
+        option instead (messages without one default to priority 4).  When
+        ``"quorum"`` is selected, ``consumer_timeout`` defaults to
+        ``1_800_000`` (30 minutes).
+      delivery_limit(int): The ``x-delivery-limit`` to declare on quorum
+        work queues for poison-message handling.  When omitted, RabbitMQ's
+        default applies; pass ``-1`` to disable.  Ignored for classic
+        queues.
       max_priority(int): Configure queues with ``x-max-priority`` to
-        support queue-global priority queueing.
+        support queue-global priority queueing.  Not supported with quorum
+        queues.
+      consumer_timeout(int): Delivery-acknowledgement timeout, in
+        milliseconds, applied to the delay queue only (via the
+        ``x-consumer-timeout`` consumer argument); work-queue messages are
+        acked when the actor finishes, so their timeout is left to the
+        server.  Also sizes the delay queue's re-lease horizon.  Must be
+        at least ``1_800_000`` (30 minutes).  Defaults to ``None`` for
+        classic queues (no re-lease) and to ``1_800_000`` for quorum
+        queues.
       parameters(list[dict]): A sequence of (pika) connection parameters
         to determine which Rabbit server(s) to connect to.
       **kwargs: The (pika) connection parameters to use to
@@ -110,14 +140,32 @@ class RabbitmqBroker(Broker):
         confirm_delivery: bool = False,
         url: Optional[Union[str, list[str]]] = None,
         middleware: Optional[list[Middleware]] = None,
+        queue_type: str = "classic",
+        delivery_limit: Optional[int] = None,
         max_priority: Optional[int] = None,
+        consumer_timeout: Optional[int] = None,
         parameters: Optional[list[dict[str, Any]]] = None,
         **kwargs: Any,
     ):
         super().__init__(middleware=middleware)
 
+        if queue_type not in ("classic", "quorum"):
+            raise ValueError("queue_type must be either 'classic' or 'quorum'")
+
+        if queue_type == "quorum":
+            if max_priority is not None:
+                raise RuntimeError(
+                    "max_priority is not supported by quorum queues; they always provide the "
+                    "full 0-31 priority range (send with the broker_priority option instead)."
+                )
+            if consumer_timeout is None:
+                consumer_timeout = MIN_CONSUMER_TIMEOUT
+
         if max_priority is not None and not (0 < max_priority <= 255):
             raise ValueError("max_priority must be a value between 0 and 255")
+
+        if consumer_timeout is not None and consumer_timeout < MIN_CONSUMER_TIMEOUT:
+            raise ValueError("consumer_timeout must be at least %d ms (30 minutes)" % MIN_CONSUMER_TIMEOUT)
 
         if url is not None:
             if parameters is not None or kwargs:
@@ -142,7 +190,15 @@ class RabbitmqBroker(Broker):
             self.parameters = pika.ConnectionParameters(**kwargs)
 
         self.confirm_delivery = confirm_delivery
+        self.queue_type = queue_type
+        self.delivery_limit = delivery_limit
         self.max_priority = max_priority
+        self._consumer_timeout = consumer_timeout
+        #: Read by the worker's delay-queue consumer to bound how long a
+        #: delayed message is held unacked before it is re-leased.
+        self.delay_queue_lease_ms = (
+            int(consumer_timeout * DELAY_QUEUE_LEASE_FACTOR) if consumer_timeout is not None else None
+        )
         self.connections: set[pika.BlockingConnection] = set()
         self.channels: set[pika.BlockingChannel] = set()
         # 'queues' is the set of Queues declared on the Broker. These are created lazily in RabbitMQ when required.
@@ -328,6 +384,10 @@ class RabbitmqBroker(Broker):
             "x-dead-letter-exchange": "",
             "x-dead-letter-routing-key": xq_name(queue_name),
         }
+        if self.queue_type == "quorum":
+            arguments["x-queue-type"] = "quorum"
+            if self.delivery_limit is not None:
+                arguments["x-delivery-limit"] = self.delivery_limit
         if self.max_priority:
             arguments["x-max-priority"] = self.max_priority
 
@@ -339,18 +399,22 @@ class RabbitmqBroker(Broker):
 
     def _declare_dq_queue(self, queue_name):
         arguments = self._build_queue_arguments(queue_name)
+        if self.queue_type == "quorum":
+            # The delay queue holds messages unacked in memory until their eta
+            # passes, so the broker must never cap their (re)deliveries -- the
+            # acknowledgement timeout would otherwise dead-letter them early.
+            arguments["x-delivery-limit"] = -1
         return self.channel.queue_declare(queue=dq_name(queue_name), durable=True, arguments=arguments)
 
     def _declare_xq_queue(self, queue_name):
-        return self.channel.queue_declare(
-            queue=xq_name(queue_name),
-            durable=True,
-            arguments={
-                # This HAS to be a static value since messages are expired
-                # in order inside of RabbitMQ (head-first).
-                "x-message-ttl": DEAD_MESSAGE_TTL,
-            },
-        )
+        arguments = {
+            # This HAS to be a static value since messages are expired
+            # in order inside of RabbitMQ (head-first).
+            "x-message-ttl": DEAD_MESSAGE_TTL,
+        }
+        if self.queue_type == "quorum":
+            arguments["x-queue-type"] = "quorum"
+        return self.channel.queue_declare(queue=xq_name(queue_name), durable=True, arguments=arguments)
 
     def enqueue(self, message: Message, *, delay: Optional[int] = None) -> Message:
         """Enqueue a message.
@@ -524,7 +588,19 @@ class _RabbitmqConsumer(Consumer):
             self.connection = pika.BlockingConnection(parameters=self.broker.parameters)
             self.channel = self.connection.channel()
             self.channel.basic_qos(prefetch_count=prefetch)
-            self.iterator = self.channel.consume(queue_name, inactivity_timeout=timeout / 1000)
+            # Only the delay queue holds messages unacked long enough to matter,
+            # so only its consumer gets an explicit x-consumer-timeout (a
+            # consumer argument, so no queue redeclaration).  Work-queue messages
+            # are acked when the actor finishes, so their timeout is left to the
+            # server.
+            consumer_arguments = {}
+            if self.queue_name.endswith(".DQ") and self.broker._consumer_timeout is not None:
+                consumer_arguments["x-consumer-timeout"] = self.broker._consumer_timeout
+            self.iterator = self.channel.consume(
+                queue_name,
+                inactivity_timeout=timeout / 1000,
+                arguments=consumer_arguments or None,
+            )
 
             # We need to keep track of known delivery tags so that
             # when connection errors occur and the consumer is reset,
@@ -614,10 +690,16 @@ class _RabbitmqConsumer(Consumer):
             # finish processing so we enqueue a final callback and
             # wait for it to finish before closing the connection.
             # Assumes callbacks are called in order (they should be).
-            all_callbacks_handled = Event()
-            self.connection.add_callback_threadsafe(all_callbacks_handled.set)
-            while not all_callbacks_handled.is_set():
-                self.connection.sleep(0)
+            if self.connection.is_open:
+                all_callbacks_handled = Event()
+                self.connection.add_callback_threadsafe(all_callbacks_handled.set)
+                while not all_callbacks_handled.is_set():
+                    self.connection.sleep(0)
+        except pika.exceptions.ConnectionWrongStateError:
+            # The connection is already closed (e.g. node shutdown or a forced
+            # close during failover), so there are no pending callbacks to
+            # drain.  Benign during node restarts.
+            self.logger.debug("Connection already closed; skipping callback drain.")
         except Exception:
             self.logger.exception(
                 "Failed to wait for all callbacks to complete.  This "

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -344,11 +344,18 @@ class ConsumerThread(Thread):
         self.logger.debug("Consumer thread stopped.")
 
     def handle_delayed_messages(self) -> None:
-        """Enqueue any delayed messages whose eta has passed."""
+        """Enqueue delayed messages whose eta has passed, or re-lease those
+        whose in-memory hold nears the broker's consumer-acknowledgement
+        timeout.
+
+        Items are keyed on ``min(eta, redeliver_at)``, so the first item
+        still in the future means nothing past it is due.  A due item is
+        either fired (eta passed) or re-enqueued to the delay queue with
+        its remaining delay.
+        """
         for item in iter_queue(self.delay_queue):
-            eta = item.priority
             message = item.message
-            if eta > current_millis():
+            if item.priority > current_millis():
                 self.delay_queue.put(item)
                 self.delay_queue.task_done()
                 break
@@ -356,8 +363,10 @@ class ConsumerThread(Thread):
             queue_name = q_name(message.queue_name)
             new_message = message.copy(queue_name=queue_name)
             del new_message.options["eta"]
+            new_message.options.pop("redeliver_at", None)
 
-            self.broker.enqueue(new_message)
+            remaining = message.options.get("eta", 0) - current_millis()
+            self.broker.enqueue(new_message, delay=remaining if remaining > 0 else None)
             self.post_process_message(message)
             self.delay_queue.task_done()
 
@@ -381,7 +390,15 @@ class ConsumerThread(Thread):
             if "eta" in message.options:
                 self.logger.debug("Pushing message %r onto delay queue.", message.message_id)
                 self.broker.emit_before("delay_message", message)
-                self.delay_queue.put(_WorkQueueItem(message.options.get("eta", 0), message))
+                eta = message.options["eta"]
+                # If the broker declares a lease, wake this message at the lease
+                # deadline to re-lease it before the consumer timeout drops it.
+                # Key the queue on whichever comes first, the eta or the lease.
+                lease_ms = getattr(self.broker, "delay_queue_lease_ms", None)
+                if lease_ms is not None:
+                    message.options["redeliver_at"] = current_millis() + lease_ms
+                priority = min(message.options.get("redeliver_at", eta), eta)
+                self.delay_queue.put(_WorkQueueItem(priority, message))
 
             else:
                 actor = self.broker.get_actor(message.actor_name)

--- a/tests/common.py
+++ b/tests/common.py
@@ -41,6 +41,24 @@ RABBITMQ_PASSWORD = os.getenv("RABBITMQ_PASSWORD", "guest")
 RABBITMQ_CREDENTIALS = pika.credentials.PlainCredentials(RABBITMQ_USERNAME, RABBITMQ_PASSWORD)
 
 
+def rabbitmq_server_version(broker):
+    """Return the connected RabbitMQ server version as a tuple of ints
+    (e.g. ``(4, 3, 1)``), or ``()`` if it can't be determined.
+    """
+    try:
+        properties = broker.connection._impl.server_properties
+        version = properties.get("version", "")
+    except Exception:
+        return ()
+
+    parts = []
+    for part in version.split("."):
+        if not part.isdigit():
+            break
+        parts.append(int(part))
+    return tuple(parts)
+
+
 def rabbit_mq_is_unreachable():
     broker = RabbitmqBroker(
         host="127.0.0.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,21 @@ def rabbitmq_broker():
 
 
 @pytest.fixture()
+def quorum_rabbitmq_broker():
+    broker = RabbitmqBroker(
+        host="127.0.0.1",
+        queue_type="quorum",
+        credentials=RABBITMQ_CREDENTIALS,
+    )
+    check_rabbitmq(broker)
+    broker.emit_after("process_boot")
+    dramatiq.set_broker(broker)
+    yield broker
+    broker.flush_all()
+    broker.close()
+
+
+@pytest.fixture()
 def redis_broker():
     broker = RedisBroker()
     check_redis(broker.client)
@@ -98,6 +113,14 @@ def stub_worker(stub_broker):
 @pytest.fixture()
 def rabbitmq_worker(rabbitmq_broker):
     worker = Worker(rabbitmq_broker, worker_threads=32)
+    worker.start()
+    yield worker
+    worker.stop()
+
+
+@pytest.fixture()
+def quorum_rabbitmq_worker(quorum_rabbitmq_broker):
+    worker = Worker(quorum_rabbitmq_broker, worker_threads=32)
     worker.start()
     yield worker
     worker.stop()

--- a/tests/test_rabbitmq_quorum.py
+++ b/tests/test_rabbitmq_quorum.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import time
+from threading import Event
+from unittest.mock import Mock, PropertyMock, patch
+
+import pika.exceptions
+import pytest
+
+import dramatiq
+from dramatiq import Worker
+from dramatiq.brokers.rabbitmq import DEAD_MESSAGE_TTL, RabbitmqBroker
+from dramatiq.common import current_millis
+from dramatiq.middleware import Middleware
+
+from .common import rabbitmq_server_version
+
+# --- Unit tests (no broker connection required) ---
+
+
+def test_quorum_broker_rejects_max_priority():
+    # Quorum queues expose a built-in 0-31 priority range, so x-max-priority
+    # is rejected by the server.  The broker should refuse it up front.
+    with pytest.raises(RuntimeError):
+        RabbitmqBroker(host="127.0.0.1", queue_type="quorum", max_priority=10)
+
+
+def test_quorum_broker_omits_delivery_limit_by_default():
+    # Given a quorum broker without an explicit delivery_limit
+    broker = RabbitmqBroker(host="127.0.0.1", queue_type="quorum")
+
+    # When I build the arguments for the main queue
+    arguments = broker._build_queue_arguments("default")
+
+    # Then it is declared as a quorum queue, without x-delivery-limit (so
+    # RabbitMQ's own default applies) and without x-max-priority.
+    assert arguments["x-queue-type"] == "quorum"
+    assert "x-delivery-limit" not in arguments
+    assert "x-max-priority" not in arguments
+
+
+def test_quorum_broker_sets_delivery_limit_when_provided():
+    # Given a quorum broker with an explicit delivery_limit
+    broker = RabbitmqBroker(host="127.0.0.1", queue_type="quorum", delivery_limit=15)
+
+    # Then the main queue carries it
+    assert broker._build_queue_arguments("default")["x-delivery-limit"] == 15
+
+
+def test_quorum_broker_declares_queues_with_correct_arguments():
+    # Given a quorum broker with an explicit delivery_limit
+    broker = RabbitmqBroker(host="127.0.0.1", queue_type="quorum", delivery_limit=15)
+
+    captured = {}
+    mock_channel = Mock()
+    mock_channel.queue_declare.side_effect = lambda queue, durable, arguments: captured.__setitem__(queue, arguments)
+
+    # When I declare the main, delay and dead-letter queues
+    with patch.object(RabbitmqBroker, "channel", new_callable=PropertyMock, return_value=mock_channel):
+        broker._declare_queue("default")
+        broker._declare_dq_queue("default")
+        broker._declare_xq_queue("default")
+
+    # Then the main queue is quorum-typed and keeps the configured limit
+    assert captured["default"]["x-queue-type"] == "quorum"
+    assert captured["default"]["x-delivery-limit"] == 15
+    assert captured["default"]["x-dead-letter-routing-key"] == "default.XQ"
+
+    # And the delay queue is quorum-typed but always disables the limit,
+    # since its messages are held unacked in memory until their eta passes.
+    assert captured["default.DQ"]["x-queue-type"] == "quorum"
+    assert captured["default.DQ"]["x-delivery-limit"] == -1
+
+    # And the dead-letter queue is quorum-typed with the message TTL and no limit.
+    assert captured["default.XQ"]["x-queue-type"] == "quorum"
+    assert captured["default.XQ"]["x-message-ttl"] == DEAD_MESSAGE_TTL
+    assert "x-delivery-limit" not in captured["default.XQ"]
+
+
+# --- Integration tests (skipped automatically when RabbitMQ is unreachable) ---
+
+
+def test_quorum_actors_can_be_sent_messages(quorum_rabbitmq_broker, quorum_rabbitmq_worker):
+    # Given an actor that writes to a database
+    database = {}
+
+    @dramatiq.actor(queue_name="quorum_put")
+    def put(key, value):
+        database[key] = value
+
+    # When I send it many messages
+    for i in range(100):
+        assert put.send("key-%d" % i, i)
+
+    # And give the worker time to process them
+    quorum_rabbitmq_broker.join(put.queue_name)
+    quorum_rabbitmq_worker.join()
+
+    # Then the database is populated
+    assert len(database) == 100
+
+
+def test_quorum_actors_retry_with_backoff_on_failure(quorum_rabbitmq_broker, quorum_rabbitmq_worker):
+    failure_time, success_time = None, None
+    succeeded = Event()
+
+    # Given an actor that fails the first time it's called
+    @dramatiq.actor(queue_name="quorum_retry", min_backoff=1000, max_backoff=5000)
+    def do_work():
+        nonlocal failure_time, success_time
+        if not failure_time:
+            failure_time = current_millis()
+            raise RuntimeError("First failure.")
+        else:
+            success_time = current_millis()
+            succeeded.set()
+
+    # When I send it a message
+    do_work.send()
+
+    # Then it eventually succeeds, after the backoff has elapsed
+    succeeded.wait(timeout=30)
+    assert success_time is not None
+    assert 1000 <= success_time - failure_time <= (2000 + 200)
+
+
+def test_quorum_actors_can_have_their_messages_delayed(quorum_rabbitmq_broker, quorum_rabbitmq_worker):
+    start_time, run_time = current_millis(), None
+
+    # Given an actor that records when it ran
+    @dramatiq.actor(queue_name="quorum_delay")
+    def record():
+        nonlocal run_time
+        run_time = current_millis()
+
+    # When I send it a delayed message
+    record.send_with_options(delay=1000)
+
+    quorum_rabbitmq_broker.join(record.queue_name)
+    quorum_rabbitmq_worker.join()
+
+    # Then it ran at least the delay later
+    assert run_time is not None
+    assert run_time - start_time >= 1000
+
+
+def test_quorum_actors_can_delay_messages_independent_of_each_other(quorum_rabbitmq_broker):
+    results = []
+
+    @dramatiq.actor(queue_name="quorum_delay_indep")
+    def append(x):
+        results.append(x)
+
+    broker = quorum_rabbitmq_broker
+    worker = Worker(broker, worker_threads=1)
+
+    try:
+        # Given two delayed messages, the later-sent one with the smaller delay
+        append.send_with_options(args=(1,), delay=1500)
+        append.send_with_options(args=(2,), delay=1000)
+
+        worker.start()
+        broker.join(append.queue_name, min_successes=20)
+        worker.join()
+
+        # Then the message with the smaller delay runs first
+        assert results == [2, 1]
+    finally:
+        worker.stop()
+
+
+def test_quorum_actors_can_have_retry_limits(quorum_rabbitmq_broker, quorum_rabbitmq_worker):
+    # Given an actor that always fails and never retries
+    @dramatiq.actor(queue_name="quorum_dlq", max_retries=0)
+    def do_work():
+        raise RuntimeError("failed")
+
+    # When I send it a message
+    do_work.send()
+
+    quorum_rabbitmq_broker.join(do_work.queue_name)
+    quorum_rabbitmq_worker.join()
+
+    # Then it lands on the dead-letter queue
+    _, _, xq_count = quorum_rabbitmq_broker.get_queue_message_counts(do_work.queue_name)
+    assert xq_count == 1
+
+
+def test_quorum_broker_declares_quorum_typed_queues(quorum_rabbitmq_broker):
+    # Given a queue created by the quorum broker
+    @dramatiq.actor(queue_name="quorum_typecheck")
+    def do_work():
+        pass
+
+    do_work.send()
+
+    # When I try to redeclare it as a classic queue
+    # Then the server rejects it, proving the queue is quorum-typed.
+    with pytest.raises(pika.exceptions.ChannelClosedByBroker):
+        quorum_rabbitmq_broker.channel.queue_declare(
+            do_work.queue_name,
+            durable=True,
+            arguments={"x-queue-type": "classic"},
+        )
+
+
+def test_quorum_broker_enqueues_messages_in_strict_priority_order(quorum_rabbitmq_broker):
+    if rabbitmq_server_version(quorum_rabbitmq_broker) < (4, 3):
+        pytest.skip("strict priorities on quorum queues require RabbitMQ 4.3+")
+
+    max_priority = 10
+    message_processing_order = []
+    queue_name = "quorum_prioritized"
+
+    # Given an actor that records the priority of each message it processes
+    @dramatiq.actor(queue_name=queue_name)
+    def do_work(message_priority):
+        message_processing_order.append(message_priority)
+
+    worker = Worker(quorum_rabbitmq_broker, worker_threads=1)
+    worker.queue_prefetch = 1
+    worker.start()
+    worker.pause()
+
+    try:
+        # When I enqueue messages with increasing priorities while paused
+        for priority in range(max_priority):
+            do_work.send_with_options(args=(priority,), broker_priority=priority)
+
+        worker.resume()
+        quorum_rabbitmq_broker.join(queue_name, timeout=5000)
+        worker.join()
+
+        # Then they are processed highest-priority first
+        assert message_processing_order == list(reversed(range(max_priority)))
+    finally:
+        worker.stop()
+
+
+def test_quorum_delayed_messages_are_re_leased_before_consumer_timeout(quorum_rabbitmq_broker):
+    # Given a broker whose delay-queue lease is far shorter than the delay,
+    # the consumer must re-lease the held message several times before its
+    # eta -- keeping long delays from tripping the consumer-ack timeout.
+    broker = quorum_rabbitmq_broker
+    broker.delay_queue_lease_ms = 1500
+
+    delay_events = []
+
+    class CountDelays(Middleware):
+        def before_delay_message(self, broker, message):
+            delay_events.append(message.message_id)
+
+    broker.add_middleware(CountDelays())
+
+    run_times = []
+
+    @dramatiq.actor(queue_name="quorum_relay")
+    def record():
+        run_times.append(current_millis())
+
+    worker = Worker(broker, worker_threads=1)
+    try:
+        # When I send a message delayed (5s) well beyond the lease (1.5s)
+        start = current_millis()
+        record.send_with_options(delay=5000)
+        worker.start()
+
+        # join() doesn't wait on unacked/in-flight delayed messages, so poll.
+        deadline = current_millis() + 15000
+        while current_millis() < deadline and not run_times:
+            time.sleep(0.1)
+
+        # Then it runs exactly once, at roughly its eta (not the lease time),
+        assert len(run_times) == 1
+        assert 5000 <= run_times[0] - start <= 9000
+        # and it was re-leased at least once on the way there.
+        assert len(delay_events) >= 2
+    finally:
+        worker.stop()


### PR DESCRIPTION
## Summary

Follow-up to #869. Per the feedback there (no new `Broker` classes in core),
this folds quorum-queue support into the existing `RabbitmqBroker` behind a
`queue_type` flag instead of a subclass, and resolves the delay-queue half of
#827. `queue_type="classic"` stays the default — today's behavior is unchanged.

### Delay-queue re-lease — `consumer_timeout` (#827)

A delivery left unacked past RabbitMQ's `consumer_timeout` (default 30 min,
enforced since 3.8.15 on any queue type) is requeued, which churns the delay
queue for delays longer than the timeout. The worker now *re-leases* a held
message at `0.75×` `consumer_timeout`, re-enqueuing it with its remaining delay
so the eta is preserved and it fires once. Worker-side; works on classic and
quorum. Defaults to `None` (unchanged) on classic, 30 min on quorum.

### `queue_type="quorum"` (RabbitMQ 4.3+)

Declares the queues as [quorum queues](https://www.rabbitmq.com/docs/quorum-queues),
reusing all the existing delay/retry machinery. Adds poison-message handling
(`x-delivery-limit`, overridable via `delivery_limit`; disabled on the delay
queue) and built-in `broker_priority` (0–31 strict, hence the 4.3 requirement;
`max_priority` is rejected).

---

Addresses #827.

> ⚠️ Not yet tested in a real (production) environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
