### PR TITLE
Fix minor typos in comments and docstrings

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -118,7 +118,7 @@ def main(args):
             elif args.benchmark == "fib":
                 dramatiq_fib_bench.send(random.randint(1, 200))
 
-    print("Done enqueing messages. Booting workers...")
+    print("Done enqueuing messages. Booting workers...")
     with memcache_pool.reserve() as client:
         client.set(counter_key, 0)
 

--- a/dramatiq/__init__.py
+++ b/dramatiq/__init__.py
@@ -78,7 +78,7 @@ __all__ = [
     "Message",
     "get_encoder",
     "set_encoder",
-    # Middlware
+    # Middleware
     "Middleware",
     # Workers
     "Worker",

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -88,7 +88,7 @@ class RabbitmqBroker(Broker):
       confirm_delivery(bool): Wait for RabbitMQ to confirm that
         messages have been committed on every call to enqueue.
         This must be enabled for Dramatiq to detect and re-declare
-        missing queues when enqueing messages.
+        missing queues when enqueuing messages.
         Defaults to False.
       url(str|list[str]): An optional connection URL.  If both a URL
         and connection parameters are provided, the URL is used.

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -444,7 +444,7 @@ def test_actors_can_prioritize_work(stub_broker):
         def lo():
             calls.append("lo")
 
-        # When I send both actors a nubmer of messages
+        # When I send both actors a number of messages
         for _ in range(10):
             lo.send()
             hi.send()

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -439,7 +439,7 @@ def test_groups_can_have_completion_callbacks(stub_broker, stub_worker, rate_lim
     g.add_completion_callback(finalize.message(42))
     g.run()
 
-    # And wait for the callback to be callled
+    # And wait for the callback to be called
     finalized.wait(timeout=30)
 
     # Then all the messages in the group should run
@@ -496,7 +496,7 @@ def test_groups_of_pipelines_can_have_completion_callbacks(stub_broker, stub_wor
     g.add_completion_callback(finalize.message(42))
     g.run()
 
-    # And wait for the callback to be callled
+    # And wait for the callback to be called
     finalized.wait(timeout=30)
 
     # Then all the messages in the group should run


### PR DESCRIPTION
Fix a handful of typos found by codespell:

- `Middlware` -> `Middleware` in `dramatiq/__init__.py`
- `enqueing` -> `enqueuing` in `dramatiq/brokers/rabbitmq.py` and `benchmarks/bench.py`
- `nubmer` -> `number` in `tests/test_actors.py`
- `callled` -> `called` in `tests/test_composition.py` (two occurrences)

All fixes are in comments and docstrings - no logic changed.