### PR TITLE
Fix Prometheus delayed_messages_inprogress gauge never returning to zero (#672)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,3 +80,4 @@ of those changes to CLEARTYPE SRL.
 | [@ABolouk](https://github.com/ABolouk)                 | Amirhossein Bolouk Asli|
 | [@JoaoAlmeida20](https://github.com/JoaoAlmeida20)     | João Almeida           |
 | [@albcunha](https://github.com/albcunha)               | Alberto Cunha          |
+| [@apoorvdarshan](https://github.com/apoorvdarshan)     | Apoorv Darshan         |

--- a/dramatiq/middleware/prometheus.py
+++ b/dramatiq/middleware/prometheus.py
@@ -21,7 +21,7 @@ import os
 import tempfile
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-from ..common import current_millis
+from ..common import current_millis, q_name
 from ..logging import get_logger
 from .middleware import Middleware
 
@@ -145,7 +145,13 @@ class Prometheus(Middleware):
             self.total_retried_messages.labels(*labels).inc()
 
     def before_delay_message(self, broker, message):
-        labels = (message.queue_name, message.actor_name)
+        # Delayed messages are held on the ".DQ" queue, but they are
+        # re-enqueued onto (and processed from) the canonical queue, where
+        # before_process_message decrements this gauge.  Use the canonical
+        # queue name here so the inc and dec land on the same label set;
+        # otherwise the ".DQ" series only ever increments and never settles
+        # back to zero.
+        labels = (q_name(message.queue_name), message.actor_name)
         self.delayed_messages.add(message.message_id)
         self.inprogress_delayed_messages.labels(*labels).inc()
 

--- a/tests/middleware/test_prometheus.py
+++ b/tests/middleware/test_prometheus.py
@@ -4,11 +4,16 @@ import time
 import urllib.request as request
 from threading import Thread
 
-from dramatiq.middleware.prometheus import _run_exposition_server
+import dramatiq
+from dramatiq import Worker
+from dramatiq.brokers.stub import StubBroker
+from dramatiq.middleware.prometheus import Prometheus
 
 
 def test_prometheus_middleware_exposes_metrics():
     # Given an instance of the exposition server
+    from dramatiq.middleware.prometheus import _run_exposition_server
+
     thread = Thread(target=_run_exposition_server, daemon=True)
     thread.start()
 
@@ -19,3 +24,41 @@ def test_prometheus_middleware_exposes_metrics():
     with request.urlopen("http://127.0.0.1:9191") as resp:
         # Then the response should be successful
         assert resp.getcode() == 200
+
+
+def test_prometheus_middleware_delayed_messages_inprogress_returns_to_zero():
+    # Given a broker with the Prometheus middleware
+    broker = StubBroker()
+    prometheus = Prometheus()
+    broker.add_middleware(prometheus)
+    broker.emit_after("process_boot")
+    dramatiq.set_broker(broker)
+
+    # And an actor
+    @dramatiq.actor
+    def do_work():
+        return 42
+
+    # And a running worker
+    worker = Worker(broker, worker_threads=1)
+    worker.start()
+    try:
+        # When I send it a delayed message and let it run to completion
+        do_work.send_with_options(delay=100)
+        broker.join(do_work.queue_name, timeout=5000)
+        worker.join()
+
+        # Then the delayed-messages-in-progress gauge should be back to zero
+        # for every queue-name label the message passed through.  The message
+        # is delayed on the ".DQ" queue but processed on the canonical queue,
+        # so the middleware must record both events against the same label or
+        # the gauge never settles back to zero.
+        gauge = prometheus.inprogress_delayed_messages
+        for labels, child in gauge._metrics.items():
+            assert child._value.get() == 0, (labels, child._value.get())
+
+        # And the in-memory delayed-message set should not leak.
+        assert prometheus.delayed_messages == set()
+    finally:
+        worker.stop()
+        broker.close()


### PR DESCRIPTION
Closes #672

### Root cause

The Prometheus middleware tracks `dramatiq_delayed_messages_inprogress` by incrementing the gauge in `before_delay_message` and decrementing it in `before_process_message`, keyed on `(queue_name, actor_name)` labels.

A delayed message lives on the `".DQ"` queue while it waits for its eta, so when `before_delay_message` fires the message's `queue_name` is e.g. `default.DQ`, and the gauge is incremented for the label `("default.DQ", actor)`.

When the eta passes, `Worker.handle_delayed_messages` re-enqueues the message onto the **canonical** queue using `q_name()` (which strips the `.DQ` suffix). The re-enqueued message keeps its `message_id`, so `before_process_message` matches it and decrements the gauge — but now the message's `queue_name` is `default`, so the decrement lands on the label `("default", actor)`.

Because the increment and decrement use **different `queue_name` labels**, the `".DQ"` series is only ever incremented and never settles back to zero (the "metric never goes down" behavior reported in the issue), while the canonical series drifts negative.

### Reproduction

Driving a real `Worker` with a `StubBroker` and the Prometheus middleware, sending one delayed message and letting it run to completion, then dumping every child of the gauge:

```python
do_work.send_with_options(delay=100)
broker.join(do_work.queue_name, timeout=5000)
worker.join()

for labels, child in prometheus.inprogress_delayed_messages._metrics.items():
    print(labels, "=", child._value.get())
```

Observed on `master` (before the fix) — the message is delayed on `default.DQ` but processed on `default`, so the two events hit different labels:

```
before_delay   queue=default.DQ  actor=do_work
before_process queue=default     actor=do_work

('default.DQ', 'do_work') = 1.0     <-- only ever incremented, never returns to zero
('default', 'do_work')    = -1.0
```

After the fix (both events recorded against the canonical queue name):

```
before_delay   queue=default.DQ  actor=do_work
before_process queue=default     actor=do_work

('default', 'do_work') = 0.0        <-- gauge settles back to zero
```

### Fix

In `before_delay_message`, normalize the queue name with the existing `q_name()` helper before building the label tuple — the same helper the worker already uses when re-enqueueing the delayed message. This makes the increment and decrement land on the same label set. The change is a one-line label normalization plus the import; it does not alter the id-tracking or any other metric.

### Tests

Added `test_prometheus_middleware_delayed_messages_inprogress_returns_to_zero` in `tests/middleware/test_prometheus.py`. It runs a delayed message through a real worker and asserts every `inprogress_delayed_messages` child returns to `0` (and that the in-memory `delayed_messages` set does not leak). The test **fails on `master`** (the `('default.DQ', 'do_work')` child is stuck at `1.0`) and passes with this change.

The middleware test module and a broad stub/worker/message/common smoke subset pass locally, and `flake8`, `black`, `isort` and `mypy` are clean on the modified files.

Disclosure: prepared with AI assistance; reviewed and verified locally.
