### PR TITLE
Re-lease delayed messages before RabbitMQ's consumer_timeout

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -148,6 +148,41 @@ failover if the currently connected node fails.
 .. _connection parameters: https://pika.readthedocs.io/en/0.12.0/modules/parameters.html
 
 
+.. _consumer-timeouts:
+
+Consumer Timeouts and Long Delays
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+RabbitMQ
+~~~~~~~~
+
+RabbitMQ requeues any delivery that is left unacknowledged past its
+`consumer acknowledgement timeout`_ (30 minutes by default).  Dramatiq keeps
+delayed and retried messages in memory until their scheduled time, so a
+message delayed for longer than that would be requeued by the server before
+it ever runs, producing a churn of redeliveries.
+
+On **RabbitMQ 3.12 and later** we recommend passing ``consumer_timeout``
+(in milliseconds, matching your server's setting).  Dramatiq then sends it
+as the ``x-consumer-timeout`` consumer argument on the delay-queue consumer
+and *re-leases* any delayed message it has held for longer than 75% of that
+value -- re-enqueueing it with its remaining delay -- so the message is never
+dropped by the server's timeout and still runs exactly once, at its eta.
+
+.. code-block:: python
+
+   from dramatiq.brokers.rabbitmq import RabbitmqBroker
+
+   rabbitmq_broker = RabbitmqBroker(host="rabbitmq", consumer_timeout=1_800_000)
+
+The value must be at least 15 minutes.  It defaults to ``None`` -- Dramatiq
+can't tell which RabbitMQ version it's talking to, and the
+``x-consumer-timeout`` consumer argument is only honoured from 3.12 onwards,
+so nothing is sent and messages aren't re-leased unless you opt in.
+
+.. _consumer acknowledgement timeout: https://www.rabbitmq.com/docs/consumers#acknowledgement-timeout
+
+
 Other brokers
 ^^^^^^^^^^^^^
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,18 @@ All notable changes to this project will be documented in this file.
 `Unreleased`_
 -------------
 
+Added
+^^^^^
+
+* Added an optional ``consumer_timeout`` to the |RabbitmqBroker|.  When set,
+  delayed messages held longer than 75% of it are re-leased so that delays and
+  retries longer than RabbitMQ's consumer acknowledgement timeout are honoured
+  instead of being requeued by the server.  Fixes `#827`_.
+  See :ref:`consumer-timeouts`.  (`@davidt99`_)
+
+.. _#827: https://github.com/Bogdanp/dramatiq/issues/827
+.. _@davidt99: https://github.com/davidt99
+
 
 `2.2.0`_ -- 2026-06-17
 ----------------------

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -415,6 +415,11 @@ execution::
   rabbitmq_broker = RabbitmqBroker(host="rabbitmq")
   dramatiq.set_broker(rabbitmq_broker)
 
+If you schedule messages with delays or retries longer than RabbitMQ's
+consumer acknowledgement timeout, pass the ``consumer_timeout`` option so
+they aren't requeued before they run.  See :ref:`consumer-timeouts` for
+details.
+
 Redis Broker
 ^^^^^^^^^^^^
 

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -42,6 +42,13 @@ DEAD_MESSAGE_TTL = int(os.getenv("dramatiq_dead_message_ttl", 86400000 * 7))
 MAX_ENQUEUE_ATTEMPTS = 6
 MAX_DECLARE_ATTEMPTS = 2
 
+#: The fraction of ``consumer_timeout`` at which a held delayed message
+#: is re-leased, keeping it under the broker's acknowledgement timeout.
+DELAY_QUEUE_LEASE_FACTOR = 0.75
+
+#: The smallest ``consumer_timeout`` Dramatiq accepts, in milliseconds.
+MIN_CONSUMER_TIMEOUT = 900_000
+
 
 class RabbitmqBroker(Broker):
     """A broker that can be used with RabbitMQ.
@@ -96,6 +103,14 @@ class RabbitmqBroker(Broker):
         to this broker.
       max_priority(int): Configure queues with ``x-max-priority`` to
         support queue-global priority queueing.
+      consumer_timeout(int): Delivery-acknowledgement timeout, in
+        milliseconds, for the delay queue.  Sent as the
+        ``x-consumer-timeout`` consumer argument (honoured by RabbitMQ
+        3.12+) and used to re-lease delayed messages held longer than
+        ``consumer_timeout * 0.75``, so delays beyond the timeout are
+        preserved instead of being requeued by the server.  Must be at
+        least ``MIN_CONSUMER_TIMEOUT``.  Defaults to ``None`` (no
+        re-lease).
       parameters(list[dict]): A sequence of (pika) connection parameters
         to determine which Rabbit server(s) to connect to.
       **kwargs: The (pika) connection parameters to use to
@@ -111,6 +126,7 @@ class RabbitmqBroker(Broker):
         url: Optional[Union[str, list[str]]] = None,
         middleware: Optional[list[Middleware]] = None,
         max_priority: Optional[int] = None,
+        consumer_timeout: Optional[int] = None,
         parameters: Optional[list[dict[str, Any]]] = None,
         **kwargs: Any,
     ):
@@ -118,6 +134,9 @@ class RabbitmqBroker(Broker):
 
         if max_priority is not None and not (0 < max_priority <= 255):
             raise ValueError("max_priority must be a value between 0 and 255")
+
+        if consumer_timeout is not None and consumer_timeout < MIN_CONSUMER_TIMEOUT:
+            raise ValueError("consumer_timeout must be at least %d ms" % MIN_CONSUMER_TIMEOUT)
 
         if url is not None:
             if parameters is not None or kwargs:
@@ -143,6 +162,11 @@ class RabbitmqBroker(Broker):
 
         self.confirm_delivery = confirm_delivery
         self.max_priority = max_priority
+        self._consumer_timeout = consumer_timeout
+        # How long the worker may hold a delayed message before re-leasing it.
+        self.delay_queue_lease_ms = (
+            int(consumer_timeout * DELAY_QUEUE_LEASE_FACTOR) if consumer_timeout is not None else None
+        )
         self.connections: set[pika.BlockingConnection] = set()
         self.channels: set[pika.BlockingChannel] = set()
         # 'queues' is the set of Queues declared on the Broker. These are created lazily in RabbitMQ when required.
@@ -156,6 +180,12 @@ class RabbitmqBroker(Broker):
     @property
     def consumer_class(self):
         return _RabbitmqConsumer
+
+    @property
+    def consumer_timeout(self) -> Optional[int]:
+        """The delivery-acknowledgement timeout, in milliseconds, or
+        ``None`` when it was not configured."""
+        return self._consumer_timeout
 
     @property
     def connection(self):
@@ -524,7 +554,18 @@ class _RabbitmqConsumer(Consumer):
             self.connection = pika.BlockingConnection(parameters=self.broker.parameters)
             self.channel = self.connection.channel()
             self.channel.basic_qos(prefetch_count=prefetch)
-            self.iterator = self.channel.consume(queue_name, inactivity_timeout=timeout / 1000)
+            # Only the delay queue holds messages unacked long enough to hit
+            # the timeout, so only its consumer sets x-consumer-timeout (a
+            # consumer argument -- no queue redeclaration, honoured by RabbitMQ
+            # 3.12+).
+            consumer_arguments = {}
+            if self.queue_name.endswith(".DQ") and self.broker.consumer_timeout is not None:
+                consumer_arguments["x-consumer-timeout"] = self.broker.consumer_timeout
+            self.iterator = self.channel.consume(
+                queue_name,
+                inactivity_timeout=timeout / 1000,
+                arguments=consumer_arguments or None,
+            )
 
             # We need to keep track of known delivery tags so that
             # when connection errors occur and the consumer is reset,

--- a/dramatiq/worker.py
+++ b/dramatiq/worker.py
@@ -344,11 +344,15 @@ class ConsumerThread(Thread):
         self.logger.debug("Consumer thread stopped.")
 
     def handle_delayed_messages(self) -> None:
-        """Enqueue any delayed messages whose eta has passed."""
+        """Enqueue delayed messages whose eta has passed, or re-lease those
+        held long enough to approach the broker's consumer timeout.
+
+        Items are keyed on ``min(eta, redeliver_at)``, so a due item is
+        either fired (eta passed) or re-enqueued with its remaining delay.
+        """
         for item in iter_queue(self.delay_queue):
-            eta = item.priority
             message = item.message
-            if eta > current_millis():
+            if item.priority > current_millis():
                 self.delay_queue.put(item)
                 self.delay_queue.task_done()
                 break
@@ -356,8 +360,10 @@ class ConsumerThread(Thread):
             queue_name = q_name(message.queue_name)
             new_message = message.copy(queue_name=queue_name)
             del new_message.options["eta"]
+            new_message.options.pop("redeliver_at", None)
 
-            self.broker.enqueue(new_message)
+            remaining = message.options.get("eta", 0) - current_millis()
+            self.broker.enqueue(new_message, delay=remaining if remaining > 0 else None)
             self.post_process_message(message)
             self.delay_queue.task_done()
 
@@ -381,7 +387,15 @@ class ConsumerThread(Thread):
             if "eta" in message.options:
                 self.logger.debug("Pushing message %r onto delay queue.", message.message_id)
                 self.broker.emit_before("delay_message", message)
-                self.delay_queue.put(_WorkQueueItem(message.options.get("eta", 0), message))
+                eta = message.options["eta"]
+                # If the broker declares a lease, key the message on whichever
+                # comes first -- its eta or the lease deadline -- so it is
+                # re-leased before the broker's consumer timeout drops it.
+                lease_ms = getattr(self.broker, "delay_queue_lease_ms", None)
+                if lease_ms is not None:
+                    message.options["redeliver_at"] = current_millis() + lease_ms
+                priority = min(message.options.get("redeliver_at", eta), eta)
+                self.delay_queue.put(_WorkQueueItem(priority, message))
 
             else:
                 actor = self.broker.get_actor(message.actor_name)

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -14,10 +14,12 @@ import dramatiq.worker
 from dramatiq import Message, QueueJoinTimeout, Worker
 from dramatiq.brokers.rabbitmq import (
     MAX_DECLARE_ATTEMPTS,
+    MIN_CONSUMER_TIMEOUT,
     RabbitmqBroker,
     _IgnoreScaryLogs,
 )
 from dramatiq.common import current_millis
+from dramatiq.middleware import Middleware
 
 from .common import (
     RABBITMQ_CREDENTIALS,
@@ -209,6 +211,61 @@ def test_rabbitmq_actors_can_delay_messages_independent_of_each_other(rabbitmq_b
 
         # I expect the latter message to have been run first
         assert results == [2, 1]
+    finally:
+        worker.stop()
+
+
+def test_rabbitmq_consumer_timeout_configures_the_delay_queue_lease():
+    # Given a broker without a consumer_timeout, no re-lease is declared
+    assert RabbitmqBroker(host="127.0.0.1").delay_queue_lease_ms is None
+
+    # Given a broker with a consumer_timeout, the lease is 75% of it
+    broker = RabbitmqBroker(host="127.0.0.1", consumer_timeout=MIN_CONSUMER_TIMEOUT)
+    assert broker.consumer_timeout == MIN_CONSUMER_TIMEOUT
+    assert broker.delay_queue_lease_ms == int(MIN_CONSUMER_TIMEOUT * 0.75)
+
+    # And a consumer_timeout below the 30-minute minimum is rejected
+    with pytest.raises(ValueError):
+        RabbitmqBroker(host="127.0.0.1", consumer_timeout=MIN_CONSUMER_TIMEOUT - 1)
+
+
+def test_rabbitmq_delayed_messages_are_re_leased_before_consumer_timeout(rabbitmq_broker):
+    # Given a broker whose delay-queue lease is far shorter than the delay,
+    # the consumer must re-lease the held message several times before its
+    # eta -- keeping long delays from tripping the consumer-ack timeout.
+    rabbitmq_broker.delay_queue_lease_ms = 1500
+
+    delay_events = []
+
+    class CountDelays(Middleware):
+        def before_delay_message(self, broker, message):
+            delay_events.append(message.message_id)
+
+    rabbitmq_broker.add_middleware(CountDelays())
+
+    run_times = []
+
+    @dramatiq.actor
+    def record():
+        run_times.append(current_millis())
+
+    worker = Worker(rabbitmq_broker, worker_threads=1)
+    try:
+        # When I send a message delayed (5s) well beyond the lease (1.5s)
+        start = current_millis()
+        record.send_with_options(delay=5000)
+        worker.start()
+
+        # join() doesn't wait on unacked/in-flight delayed messages, so poll.
+        deadline = current_millis() + 15000
+        while current_millis() < deadline and not run_times:
+            time.sleep(0.1)
+
+        # Then it runs exactly once, at roughly its eta (not the lease time),
+        assert len(run_times) == 1
+        assert 5000 <= run_times[0] - start <= 9000
+        # and it was re-leased at least once on the way there.
+        assert len(delay_events) >= 2
     finally:
         worker.stop()
 


### PR DESCRIPTION
RabbitMQ requeues any delivery left unacked past its consumer_timeout (default 30 min, enforced since 3.8.15 on any queue type). Dramatiq holds delayed/retried messages unacked in memory until their eta, so a delay longer than the timeout is requeued by the server before it runs, churning the delay queue (#827).

Add an optional consumer_timeout to RabbitmqBroker. When set, it is sent as an x-consumer-timeout consumer argument on the delay-queue consumer only (honoured by RabbitMQ 3.12+), and the worker re-leases a held delayed message at 0.75x that value -- re-enqueuing it with its remaining delay so the eta is preserved and it still fires exactly once. Worker-side and queue-type agnostic; defaults to None (unchanged), minimum 15 minutes.

Addresses #827.