### PR TITLE
Store exceptions for messages whose actor isn't registered (#448)

### DIFF
--- a/dramatiq/results/middleware.py
+++ b/dramatiq/results/middleware.py
@@ -84,12 +84,12 @@ class Results(Middleware):
 
     def _lookup_options(self, broker, message):
         try:
-            actor = broker.get_actor(message.actor_name)
-            store_results = message.options.get("store_results", actor.options.get("store_results", self.store_results))
-            result_ttl = message.options.get("result_ttl", actor.options.get("result_ttl", self.result_ttl))
-            return store_results, result_ttl
+            actor_options = broker.get_actor(message.actor_name).options
         except ActorNotFound:
-            return False, 0
+            actor_options = {}
+        store_results = message.options.get("store_results", actor_options.get("store_results", self.store_results))
+        result_ttl = message.options.get("result_ttl", actor_options.get("result_ttl", self.result_ttl))
+        return store_results, result_ttl
 
     def after_process_message(self, broker, message, *, result=None, exception=None):
         store_results, result_ttl = self._lookup_options(broker, message)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 import pytest
 
 import dramatiq
+from dramatiq.broker import MessageProxy
+from dramatiq.errors import ActorNotFound
 from dramatiq.message import Message
 from dramatiq.middleware import Middleware, SkipMessage
 from dramatiq.results import ResultFailure, ResultMissing, Results, ResultTimeout
@@ -214,6 +216,30 @@ def test_messages_without_actor_not_crashing_lookup_options(stub_broker, redis_r
         options={},
     )
     assert Results(backend=redis_result_backend).after_nack(stub_broker, message) is None
+
+
+def test_messages_store_exception_when_actor_not_found(stub_broker, redis_result_backend):
+    # Given a message with store_results enabled for an actor that isn't registered
+    message = Message(
+        queue_name="default",
+        actor_name="idontexist",
+        args=(),
+        kwargs={},
+        options={"store_results": True},
+    )
+
+    # And a proxy that has failed with ActorNotFound, mimicking what the
+    # worker does when it receives a message for an undefined actor
+    proxy = MessageProxy(message)
+    proxy.fail()
+    proxy.stuff_exception(ActorNotFound(message.actor_name))
+
+    # When the results middleware handles the nack
+    Results(backend=redis_result_backend).after_nack(stub_broker, proxy)
+
+    # Then the exception should have been stored and be retrievable
+    with pytest.raises(ResultFailure):
+        message.get_result(backend=redis_result_backend)
 
 
 def test_messages_can_fail_to_get_results_if_there_is_no_backend(stub_broker, stub_worker):


### PR DESCRIPTION
Fix #448: store exceptions for messages whose actor isn't registered

## Problem

When a worker receives a message for an actor that isn't registered locally
(`ActorNotFound`), the `Results` middleware never stores the resulting
exception, even when the message explicitly requested `store_results=True`.
A caller blocked on `message.get_result(block=True)` therefore never gets a
result or exception — it just hangs until it times out with no diagnostic.

## Root cause

`dramatiq/results/middleware.py`, `Results._lookup_options()`. The `except
ActorNotFound` branch returned `(False, 0)` unconditionally, discarding the
`store_results` / `result_ttl` values that were actually configured on the
message (or on the middleware defaults):

```python
def _lookup_options(self, broker, message):
    try:
        actor = broker.get_actor(message.actor_name)
        store_results = message.options.get("store_results", actor.options.get("store_results", self.store_results))
        result_ttl = message.options.get("result_ttl", actor.options.get("result_ttl", self.result_ttl))
        return store_results, result_ttl
    except ActorNotFound:
        return False, 0
```

Because `store_results` was forced to `False`, `after_nack()` skipped the
`self.backend.store_exception(...)` call for the undefined actor, and the
failure was silently dropped.

## Fix

Only the actor lookup is guarded now; when the actor isn't found we simply
fall back to empty actor options and keep the existing precedence chain
(message option → actor option → middleware default). This matches the
solution suggested by @LincolnPuzey on the issue ("change `_lookup_options`
to still consider the message/default options when actor is not found").

```python
def _lookup_options(self, broker, message):
    try:
        actor_options = broker.get_actor(message.actor_name).options
    except ActorNotFound:
        actor_options = {}
    store_results = message.options.get("store_results", actor_options.get("store_results", self.store_results))
    result_ttl = message.options.get("result_ttl", actor_options.get("result_ttl", self.result_ttl))
    return store_results, result_ttl
```

## Tests

Added `test_messages_store_exception_when_actor_not_found` to
`tests/test_results.py`. It builds a message for an unregistered actor with
`store_results=True`, wraps it in a `MessageProxy` that has failed with an
`ActorNotFound` exception (mimicking `Worker` at `dramatiq/worker.py:390-397`),
runs it through `Results.after_nack()`, and asserts the exception is stored and
retrievable via `message.get_result()` (raises `ResultFailure`).

The existing `test_messages_without_actor_not_crashing_lookup_options` is kept
unchanged and still passes, guarding the no-store / no-crash path (unregistered
actor, `store_results` not requested).

## Verification (before / after)

Command:
`python -m pytest tests/test_results.py::test_messages_store_exception_when_actor_not_found`

- Before the fix: FAILED — `dramatiq.results.errors.ResultMissing: idontexist()`
  (the exception was never stored).
- After the fix: PASSED.

Full results suite (Redis + Memcached + Stub backends all running):
`python -m pytest tests/test_results.py` → 40 passed.
`python -m pytest tests/test_worker.py` → 3 passed.

Linters on the changed files: `black --check`, `isort -c`, `flake8`, and
`mypy` all clean.

## Compatibility

Backwards compatible. For a registered actor the behaviour is byte-for-byte
identical (same precedence chain). The only behavioural change is in the
`ActorNotFound` path: `store_results` / `result_ttl` now honour whatever the
message (or middleware default) configured instead of being forced to
`(False, 0)`. Messages that don't opt into `store_results` are unaffected.
