### PR TITLE
Add a client-side time budget to RabbitmqBroker.enqueue

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -291,6 +291,15 @@ These are the environment variables that dramatiq reads
    * - ``dramatiq_dead_message_ttl``
      - 604800000 (One week)
      - The maximum amount of time a message can be in the dead letter queue for the RabbitMQ Broker (in milliseconds).
+   * - ``dramatiq_max_enqueue_duration``
+     - 0 (disabled)
+     - An optional wall-clock budget, in milliseconds, for a single enqueue call on the RabbitMQ Broker. Retries stop once it is exhausted. It is checked between attempts, so the real ceiling is the budget plus one attempt. 0 leaves the attempt count as the only bound.
+   * - ``dramatiq_max_enqueue_attempts``
+     - 6
+     - The maximum number of times the RabbitMQ Broker attempts an enqueue operation in case of a connection error.
+   * - ``dramatiq_max_declare_attempts``
+     - 2
+     - The maximum number of times the RabbitMQ Broker attempts to declare a queue in case of a connection error.
    * - ``dramatiq_group_callback_barrier_ttl``
      - 86400000 (One day)
      - Deprecated. Use the `barrier_ttl` parameter of |GroupCallbacks| middleware instead.

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -39,8 +39,13 @@ DEAD_MESSAGE_TTL = int(os.getenv("dramatiq_dead_message_ttl", 86400000 * 7))
 
 #: The max number of times to attempt an enqueue operation in case of
 #: a connection error.
-MAX_ENQUEUE_ATTEMPTS = 6
-MAX_DECLARE_ATTEMPTS = 2
+MAX_ENQUEUE_ATTEMPTS = int(os.getenv("dramatiq_max_enqueue_attempts", 6))
+MAX_DECLARE_ATTEMPTS = int(os.getenv("dramatiq_max_declare_attempts", 2))
+
+#: An optional wall-clock budget, in milliseconds, for a single enqueue call.
+#: Retries stop once it is exhausted; 0 (the default) leaves the attempt count
+#: as the only bound.
+MAX_ENQUEUE_DURATION = int(os.getenv("dramatiq_max_enqueue_duration", 0))
 
 
 class RabbitmqBroker(Broker):
@@ -321,6 +326,7 @@ class RabbitmqBroker(Broker):
                     "Retrying declare due to closed connection. [%d/%d] attempts made so far.",
                     attempts,
                     MAX_DECLARE_ATTEMPTS,
+                    exc_info=True,
                 )
 
     def _build_queue_arguments(self, queue_name):
@@ -378,6 +384,7 @@ class RabbitmqBroker(Broker):
             )
 
         attempts = 0
+        deadline = MAX_ENQUEUE_DURATION and time.monotonic() + MAX_ENQUEUE_DURATION / 1000
         while True:
             try:
                 self.declare_queue(canonical_queue_name, ensure=True)
@@ -415,6 +422,15 @@ class RabbitmqBroker(Broker):
                     self.queues_pending.add(q_name(queue_name))
 
                 attempts += 1
+                if deadline and time.monotonic() >= deadline:
+                    self.logger.debug(
+                        "Giving up on enqueue after %d attempt(s): time budget of %dms exhausted.",
+                        attempts,
+                        MAX_ENQUEUE_DURATION,
+                        exc_info=True,
+                    )
+                    raise ConnectionClosed(e) from None
+
                 if attempts >= MAX_ENQUEUE_ATTEMPTS:
                     raise ConnectionClosed(e) from None
 
@@ -422,6 +438,7 @@ class RabbitmqBroker(Broker):
                     "Retrying enqueue due to closed connection. [%d/%d] attempts made so far.",
                     attempts,
                     MAX_ENQUEUE_ATTEMPTS,
+                    exc_info=True,
                 )
 
     def get_declared_queues(self) -> set[str]:

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -14,6 +14,7 @@ import dramatiq.worker
 from dramatiq import Message, QueueJoinTimeout, Worker
 from dramatiq.brokers.rabbitmq import (
     MAX_DECLARE_ATTEMPTS,
+    MAX_ENQUEUE_ATTEMPTS,
     RabbitmqBroker,
     _IgnoreScaryLogs,
 )
@@ -278,6 +279,36 @@ def test_rabbitmq_broker_stops_retrying_declaring_queues_when_max_attempts_reach
 
     # check declare was attempted the max number of times.
     assert mock_declare_queue.call_count == MAX_DECLARE_ATTEMPTS
+
+
+def test_rabbitmq_enqueue_gives_up_when_time_budget_exhausted(rabbitmq_broker):
+    # Given a short enqueue time budget
+    # And a publish that always fails with a connection error, slowly enough
+    # to exhaust that budget on the first attempt
+    def slow_failing_publish(*args, **kwargs):
+        time.sleep(0.05)
+        raise pika.exceptions.AMQPConnectionError
+
+    with (
+        patch("dramatiq.brokers.rabbitmq.MAX_ENQUEUE_DURATION", 10),
+        patch.object(
+            rabbitmq_broker.channel,
+            "basic_publish",
+            side_effect=slow_failing_publish,
+        ) as mock_basic_publish,
+    ):
+        # When I declare and use an actor
+        # Then a ConnectionClosed error should be raised
+        with pytest.raises(dramatiq.errors.ConnectionClosed):
+
+            @dramatiq.actor(queue_name="flaky_queue")
+            def do_work():
+                pass
+
+            do_work.send()
+
+    # check enqueue gave up on the time budget before reaching the attempt limit.
+    assert mock_basic_publish.call_count < MAX_ENQUEUE_ATTEMPTS
 
 
 def test_rabbitmq_messages_belonging_to_missing_actors_are_rejected(rabbitmq_broker, rabbitmq_worker):


### PR DESCRIPTION
In a clustered broker, an ungraceful node loss (frozen VM, partition) blocks a confirmed publish for ~net_ticktime (60s) instead of failing fast, and enqueue retries that up to MAX_ENQUEUE_ATTEMPTS times -- a single send can stall for minutes.

- dramatiq_max_enqueue_duration: optional per-enqueue wall-clock budget (ms, 0/default off). Checked between attempts, so it caps the retry loop at ~budget + one attempt.
- Make MAX_ENQUEUE_ATTEMPTS / MAX_DECLARE_ATTEMPTS env-configurable.

Although it's more relevant to quorum queues, I've validated it affects also classic queues in a cluster mode.