### PR TITLE
Do not log expected Exception+Stack Trace when RabbitMQ server shuts down

### DIFF
--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -26,6 +26,7 @@ from threading import Event, local
 from typing import Any, Optional, Union
 
 import pika
+import pika.exceptions
 
 from ..broker import Broker, Consumer, MessageProxy
 from ..common import current_millis, dq_name, q_name, xq_name
@@ -618,6 +619,10 @@ class _RabbitmqConsumer(Consumer):
             self.connection.add_callback_threadsafe(all_callbacks_handled.set)
             while not all_callbacks_handled.is_set():
                 self.connection.sleep(0)
+        except pika.exceptions.ConnectionWrongStateError:
+            # The connection is already closed or closing (e.g. server shutdown),
+            # so pika doesn't allow adding a callback.
+            self.logger.debug("Connection already closed, skipping waiting for callbacks to finish.")
         except Exception:
             self.logger.exception(
                 "Failed to wait for all callbacks to complete.  This "


### PR DESCRIPTION
Catch ConnectionWrongStateError when adding final connection callback.

`connection.add_callback_threadsafe` raises `ConnectionWrongStateError` when the connection is already closed. When this exception happens, catch it and only log a debug message. Previously, the exception+stack trace was logged at error level. The reduces the amount of noise in the logs when the RabbitMQ server is shutdown while workers are running.

Fix extracted from commit ed9850fd60bd909530a828979eaa3b4c757ae1ae

Closes #187 