### PR TITLE
Store ActorNotFound failures when store_results is set

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,3 +80,4 @@ of those changes to CLEARTYPE SRL.
 | [@ABolouk](https://github.com/ABolouk)                 | Amirhossein Bolouk Asli|
 | [@JoaoAlmeida20](https://github.com/JoaoAlmeida20)     | João Almeida           |
 | [@albcunha](https://github.com/albcunha)               | Alberto Cunha          |
+| [@DSeaStar](https://github.com/DSeaStar)               | SeaStar Deng           |

--- a/dramatiq/results/middleware.py
+++ b/dramatiq/results/middleware.py
@@ -82,14 +82,32 @@ class Results(Middleware):
             "result_ttl",
         }
 
+    def before_enqueue(self, broker, message, delay):
+        """Copy store_results/result_ttl onto the message so a worker
+        that does not have the actor imported can still persist failures.
+        """
+        try:
+            actor = broker.get_actor(message.actor_name)
+        except ActorNotFound:
+            return
+
+        store_results = message.options.get("store_results", actor.options.get("store_results", self.store_results))
+        if store_results and "store_results" not in message.options:
+            message.options["store_results"] = True
+            message.options.setdefault("result_ttl", actor.options.get("result_ttl", self.result_ttl))
+
     def _lookup_options(self, broker, message):
         try:
             actor = broker.get_actor(message.actor_name)
-            store_results = message.options.get("store_results", actor.options.get("store_results", self.store_results))
-            result_ttl = message.options.get("result_ttl", actor.options.get("result_ttl", self.result_ttl))
-            return store_results, result_ttl
+            actor_store_results = actor.options.get("store_results", self.store_results)
+            actor_result_ttl = actor.options.get("result_ttl", self.result_ttl)
         except ActorNotFound:
-            return False, 0
+            actor_store_results = self.store_results
+            actor_result_ttl = self.result_ttl
+
+        store_results = message.options.get("store_results", actor_store_results)
+        result_ttl = message.options.get("result_ttl", actor_result_ttl)
+        return store_results, result_ttl
 
     def after_process_message(self, broker, message, *, result=None, exception=None):
         store_results, result_ttl = self._lookup_options(broker, message)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 import dramatiq
+from dramatiq import Worker
 from dramatiq.message import Message
 from dramatiq.middleware import Middleware, SkipMessage
 from dramatiq.results import ResultFailure, ResultMissing, Results, ResultTimeout
@@ -214,6 +215,54 @@ def test_messages_without_actor_not_crashing_lookup_options(stub_broker, redis_r
         options={},
     )
     assert Results(backend=redis_result_backend).after_nack(stub_broker, message) is None
+
+
+def test_results_middleware_stamps_store_results_on_enqueue(stub_broker, stub_result_backend):
+    # Given a broker with the results middleware
+    stub_broker.add_middleware(Results(backend=stub_result_backend))
+
+    # And an actor that stores results
+    @dramatiq.actor(store_results=True)
+    def do_work():
+        return 42
+
+    # When I enqueue a message
+    message = do_work.send()
+
+    # Then store_results is copied onto the message so a worker
+    # without this actor imported can still persist failures
+    assert message.options.get("store_results") is True
+
+
+def test_actor_not_found_stores_exception_when_store_results_is_set(stub_broker, stub_result_backend):
+    # Given a broker with the results middleware
+    stub_broker.add_middleware(Results(backend=stub_result_backend))
+
+    # And an actor that stores results
+    @dramatiq.actor(store_results=True, max_retries=0)
+    def do_work():
+        return 42
+
+    # When I enqueue a message and then remove the actor (as if the
+    # worker process never imported it)
+    message = do_work.send()
+    del stub_broker.actors[do_work.actor_name]
+
+    # And a worker processes that message
+    worker = Worker(stub_broker, worker_threads=1)
+    worker.start()
+    try:
+        stub_broker.join(do_work.queue_name, fail_fast=False)
+        worker.join()
+    finally:
+        worker.stop()
+
+    # Then the missing-actor failure is stored so get_result unblocks
+    with pytest.raises(ResultFailure) as e:
+        stub_result_backend.get_result(message, block=True, timeout=1000)
+
+    assert e.value.orig_exc_type == "ActorNotFound"
+    assert do_work.actor_name in e.value.orig_exc_msg
 
 
 def test_messages_can_fail_to_get_results_if_there_is_no_backend(stub_broker, stub_worker):


### PR DESCRIPTION
Fixes #448.

When a worker receives a message for an actor that is not imported locally, `Results._lookup_options()` treated `store_results` as false. `after_nack` then skipped the result backend, so `message.get_result()` waited until timeout instead of raising `ActorNotFound`.

The producer already knows the actor's options. `before_enqueue` now copies `store_results` / `result_ttl` onto the message, and `_lookup_options` falls back to those (then the middleware defaults) when the actor is missing. A worker that never imported the actor can still persist the failure.

Messages that never asked for results are unchanged: `after_nack` still no-ops when `store_results` is unset.