### PR TITLE
Fix concurrent StreamablePipe writes

### DIFF
--- a/dramatiq/compat.py
+++ b/dramatiq/compat.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 # Don't depend on *anything* in this module.  The contents of this
 # module can and *will* change without notice.
 import sys
+import threading
 from contextlib import contextmanager
 
 
@@ -36,6 +37,18 @@ class StreamablePipe:
     def __init__(self, pipe, *, encoding="utf-8"):
         self.encoding = encoding
         self.pipe = pipe
+        self._write_lock = threading.Lock()
+
+    def __getstate__(self):
+        return {
+            "encoding": self.encoding,
+            "pipe": self.pipe,
+        }
+
+    def __setstate__(self, state):
+        self.encoding = state["encoding"]
+        self.pipe = state["pipe"]
+        self._write_lock = threading.Lock()
 
     def fileno(self):
         return self.pipe.fileno()
@@ -53,7 +66,10 @@ class StreamablePipe:
         raise NotImplementedError("StreamablePipes cannot be read from!")
 
     def write(self, s):
-        self.pipe.send_bytes(s.encode(self.encoding, errors="replace"))
+        # send_bytes splits large frames into a header and payload write.  Keep
+        # concurrent stderr/stdout writers from interleaving those frames.
+        with self._write_lock:
+            self.pipe.send_bytes(s.encode(self.encoding, errors="replace"))
 
     @property
     def closed(self):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,69 @@
+# This file is a part of Dramatiq.
+#
+# Copyright (C) 2026 CLEARTYPE SRL <bogdan@cleartype.io>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pickle
+import threading
+import time
+
+from dramatiq.compat import StreamablePipe
+
+
+class SlowPipe:
+    def __init__(self):
+        self.active_writes = 0
+        self.concurrent_writes = False
+        self.lock = threading.Lock()
+
+    def send_bytes(self, data):
+        with self.lock:
+            self.active_writes += 1
+            self.concurrent_writes |= self.active_writes > 1
+
+        time.sleep(0.01)
+
+        with self.lock:
+            self.active_writes -= 1
+
+
+class PickleablePipe:
+    pass
+
+
+def test_streamable_pipe_serializes_writes():
+    pipe = SlowPipe()
+    stream = StreamablePipe(pipe)
+    start = threading.Barrier(2)
+
+    def write():
+        start.wait()
+        stream.write("message")
+
+    writers = [threading.Thread(target=write) for _ in range(2)]
+    for writer in writers:
+        writer.start()
+    for writer in writers:
+        writer.join()
+
+    assert not pipe.concurrent_writes
+
+
+def test_streamable_pipe_can_be_pickled():
+    stream = StreamablePipe(PickleablePipe())
+    restored = pickle.loads(pickle.dumps(stream))
+
+    assert restored.encoding == "utf-8"
+    assert isinstance(restored.pipe, PickleablePipe)


### PR DESCRIPTION
## Summary

- serialize `StreamablePipe.write()` calls with a per-pipe lock
- recreate the lock after unpickling to support spawned worker processes
- add regression coverage for concurrent writes and pickling

`Connection.send_bytes()` splits large frames into separate header and payload writes. Without serialization, concurrent writers sharing one `StreamablePipe` can interleave those writes and corrupt the parent log watcher stream.

Fixes #888.

## Validation

- focused `StreamablePipe` regression tests
- `flake8 dramatiq/compat.py tests/test_compat.py`
- five-writer, 128 KiB frame reproduction: all 500 frames are received with this patch