### PR TITLE
Drop Python 3.10 Support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install --group format
       - run: black --check .
 
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install ".[all]" --group type-check
       - run: mypy
 
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install --group lint
       - run: isort --check dramatiq tests
 
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install --group lint
       - run: flake8 dramatiq tests examples
 
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install ".[all]" --group docs
       - run: cd docs && make html
 
@@ -57,11 +57,9 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-24.04"]
-        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
         concurrency: ["cpython", "free-threaded", "gevent"]
         exclude:
-          - python: "3.10"
-            concurrency: "free-threaded"
           - python: "3.11"
             concurrency: "free-threaded"
           - python: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: pip install --group build

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ Here's what it looks like:
   count_words.send("http://example.com")
 
 **Dramatiq** is :doc:`licensed<license>` under the LGPL and it
-officially supports Python 3.10 and later.
+officially supports Python 3.11 and later.
 
 
 Get It Now

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-Dramatiq supports Python versions 3.10 and up and is installable via
+Dramatiq supports Python versions 3.11 and up and is installable via
 `pip`_ or from source.
 
 

--- a/dramatiq/asyncio.py
+++ b/dramatiq/asyncio.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import functools
 import logging
 import threading
@@ -147,10 +146,7 @@ class EventLoopThread(threading.Thread):
                     # Use a timeout to be able to catch asynchronously
                     # raised dramatiq exceptions (Interrupt).
                     return future.result(timeout=self.interrupt_check_ival)
-                except (
-                    # TODO replace with built-in TimeoutError once 3.10 support dropped.
-                    concurrent.futures.TimeoutError
-                ):
+                except TimeoutError:
                     # NOTE: TimeoutError caught here could be from future.result() timing out (i.e. future not done yet),
                     # or a TimeoutError raised inside the future itself (future is done).
                     if not future.done():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ source = ['dramatiq', 'tests']
 
 [tool.black]
 line-length = 120
-target-version = ["py310", "py311", "py312", "py313", "py314"]
+target-version = ["py311", "py312", "py313", "py314"]
 
 [tool.isort]
 line_length = 120
@@ -69,7 +69,7 @@ add_imports = [
 
 [tool.mypy]
 packages = ["dramatiq", "tests"]
-python_version = "3.10"
+python_version = "3.11"
 pretty = true
 show_column_numbers = true
 show_error_context = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 80.9.0, < 81"]
+requires = ["setuptools >= 84.0.0, < 85"]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]

--- a/setup.py
+++ b/setup.py
@@ -87,12 +87,11 @@ setup(
         "dramatiq.results.backends",
     ],
     include_package_data=True,
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     extras_require=extra_dependencies,
     entry_points={"console_scripts": ["dramatiq = dramatiq.__main__:main"]},
     scripts=["bin/dramatiq-gevent"],
     classifiers=[
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ extra_dependencies = {
         "pika>=1.0,<2.0",
     ],
     "redis": [
-        "redis>=4.0,<9.0",
+        "redis>=5.0.0,<9.0",
     ],
     "watch": [
         "watchdog>=6.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-  py{310,311,312,313,314}{,-gevent}
+  py{311,312,313,314}{,-gevent}
   docs
   lint
 
@@ -16,7 +16,7 @@ commands=
 passenv=
   TRAVIS
 
-[testenv:py{310,311,312,313,314}-gevent]
+[testenv:py{311,312,313,314}-gevent]
 setenv =
     PYTHONTRACEMALLOC=1
 dependency_groups=


### PR DESCRIPTION
Upstream Python 3.10 support ends in October: https://peps.python.org/pep-0619/#lifespan

This is likely after our next release, plus we should add 3.15 support soon.

This PR:
* Drops 3.10 support. 3.11 is the minimum.
* Updates setuptools version
* Bumps minimum redis version, because 4.0.0 only declares support for 3.6 to 3.10